### PR TITLE
Zindex

### DIFF
--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -366,7 +366,7 @@ function expRewrite() {
         .style("border-radius", "30px")
         .style("pointer-events", "none")
         .style("opacity", 0)
-        .style("z-index", 100)
+        .style("z-index", 999999)
     bars.on("mouseover", function (d) {
         propTable = buildPropertyTooltipTable(d)
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -366,6 +366,7 @@ function expRewrite() {
         .style("border-radius", "30px")
         .style("pointer-events", "none")
         .style("opacity", 0)
+        .style("z-index", 100)
     bars.on("mouseover", function (d) {
         propTable = buildPropertyTooltipTable(d)
 


### PR DESCRIPTION
tooltips would show up behind other elements.  Especially a problem when the tooltip went below another tripal pane.