### PR TITLE
delay map plot until pane opens

### DIFF
--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -3,14 +3,17 @@
  * It is also called when the reset link is clicked.
  */
 function expNormal() {
-    heatMapTotal = '';
-    heatMapTotal = JSON.parse(JSON.stringify(heatMapRaw));
-    //Get samples associated with selected analysis
-    selectedAnalysis = d3.select('#analyses').property('value');
-    heatMap = heatMapTotal[selectedAnalysis].biomaterials;
-    buildPropertySelect();
-    d3.selectAll('chart').remove();
-    expRewrite();
+    jQuery('.tripal_pane').on('tripal_ds_pane_expanded', function () {
+        heatMapTotal = '';
+        heatMapTotal = JSON.parse(JSON.stringify(heatMapRaw));
+        //Get samples associated with selected analysis
+        selectedAnalysis = d3.select('#analyses').property('value');
+        heatMap = heatMapTotal[selectedAnalysis].biomaterials;
+        buildPropertySelect();
+        d3.selectAll('chart').remove();
+        expRewrite();
+
+    });
 }
 
 function expRewrite() {


### PR DESCRIPTION
This PR fixed #95 plot not showing up when the pane was expanded on my old version of the theme.   Updating my theme breaks the fix.
