### PR TITLE
Primary vs external loader

### DIFF
--- a/tripal_biomaterial/includes/TripalFields/sio__primary_cross_reference/sio__primary_cross_reference.inc
+++ b/tripal_biomaterial/includes/TripalFields/sio__primary_cross_reference/sio__primary_cross_reference.inc
@@ -1,0 +1,188 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Data:
+ * Assumptions:
+ */
+class sio__primary_cross_reference extends ChadoField {
+
+  // --------------------------------------------------------------------------
+  //                     EDITABLE STATIC CONSTANTS
+  //
+  // The following constants SHOULD be set for each descendant class.  They are
+  // used by the static functions to provide information to Drupal about
+  // the field and it's default widget and formatter.
+  // --------------------------------------------------------------------------
+
+  // The default label for this field.
+  public static $default_label = 'primary cross reference';
+
+  // The default description for this field.
+  public static $default_description = 'The primary cross reference is a database cross reference in which one entity is equivalent to the other and it serves as the primary reference.';
+
+  // The default widget for this field.
+  public static $default_widget = 'sio__primary_cross_reference_widget';
+
+  // The default formatter for this field.
+  public static $default_formatter = 'sio__primary_cross_reference_formatter';
+
+  // The module that manages this field.
+  public static $module = 'tripal_biomaterial';
+
+  // A list of global settings. These can be accessed within the
+  // globalSettingsForm.  When the globalSettingsForm is submitted then
+  // Drupal will automatically change these settings for all fields.
+  // Once instances exist for a field type then these settings cannot be
+  // changed.
+  public static $default_settings = [
+    'storage' => 'field_chado_storage',
+    // It is expected that all fields set a 'value' in the load() function.
+    // In many cases, the value may be an associative array of key/value pairs.
+    // In order for Tripal to provide context for all data, the keys should
+    // be a controlled vocabulary term (e.g. rdfs:type). Keys in the load()
+    // function that are supported by the query() function should be
+    // listed here.
+    'searchable_keys' => [],
+  ];
+
+  // Provide a list of instance specific settings. These can be access within
+  // the instanceSettingsForm.  When the instanceSettingsForm is submitted
+  // then Drupal with automatically change these settings for the instance.
+  // It is recommended to put settings at the instance level whenever possible.
+  // If you override this variable in a child class be sure to replicate the
+  // term_name, term_vocab, term_accession and term_fixed keys as these are
+  // required for all TripalFields.
+  public static $default_instance_settings = [
+    // The DATABASE name, as it appears in chado.db.  This also builds the link-out url.  In most cases this will simply be the CV name.  In some cases (EDAM) this will be the SUBONTOLOGY.
+    'term_vocabulary' => 'SIO',
+    // The name of the term.
+    'term_name' => 'primary_cross_reference',
+    // The unique ID (i.e. accession) of the term.
+    'term_accession' => '001172',
+    // Set to TRUE if the site admin is not allowed to change the term
+    // type, otherwise the admin can change the term mapped to a field.
+    'term_fixed' => FALSE,
+    // Indicates if this field should be automatically attached to display
+    // or web services or if this field should be loaded separately. This
+    // is convenient for speed.  Fields that are slow should for loading
+    // should have auto_attach set to FALSE so tha their values can be
+    // attached asynchronously.
+    'auto_attach' => FALSE,
+    // The table in Chado that the instance maps to.
+    'chado_table' => 'dbxref',
+    // The column of the table in Chado where the value of the field comes from.
+    'chado_column' => 'dbxref_id',
+    // The base table.
+    'base_table' => 'biomaterial',
+  ];
+
+  // A boolean specifying that users should not be allowed to create
+  // fields and instances of this field type through the UI. Such
+  // fields can only be created programmatically with field_create_field()
+  // and field_create_instance().
+  public static $no_ui = FALSE;
+
+  // A boolean specifying that the field will not contain any data. This
+  // should exclude the field from web services or downloads.  An example
+  // could be a quick search field that appears on the page that redirects
+  // the user but otherwise provides no data.
+  public static $no_data = FALSE;
+
+  /**
+   * Loads the field values from the underlying data store.
+   *
+   * @param $entity
+   *
+   * @return
+   *   An array of the following format:
+   *     $entity->{$field_name}['und'][0]['value'] = $value;
+   *   where:
+   *     - $entity is the entity object to which this field is attached.
+   *     - $field_name is the name of this field
+   *     - 'und' is the language code (in this case 'und' == undefined)
+   *     - 0 is the cardinality.  Increment by 1 when more than one item is
+   *       available.
+   *     - 'value' is the key indicating the value of this field. It should
+   *       always be set.  The value of the 'value' key will be the contents
+   *       used for web services and for downloadable content.  The value
+   *       should be of the follow format types: 1) A single value (text,
+   *       numeric, etc.) 2) An array of key value pair. 3) If multiple entries
+   *       then cardinality should incremented and format types 1 and 2 should
+   *       be used for each item.
+   *   The array may contain as many other keys at the same level as 'value'
+   *   but those keys are for internal field use and are not considered the
+   *   value of the field.
+   *
+   *
+   */
+  public function load($entity) {
+    parent::load($entity);
+    //
+    //    $record = $entity->chado_record;
+    //
+    //    $field_name = $this->field['field_name'];
+    //    $field_type = $this->field['type'];
+    //    $field_table = $this->instance['settings']['chado_table'];
+    //    $field_column = $this->instance['settings']['chado_column'];
+    //    $base_table = $record->tablename;
+    //
+    //    $schema = chado_get_schema($field_table);
+    //    $pkey = $schema['primary key'][0];
+    //    $fkey_lcolumn = key($schema['foreign keys'][$base_table]['columns']);
+    //    $fkey_rcolumn = $schema['foreign keys'][$base_table]['columns'][$fkey_lcolumn];
+    //
+    //    $dbname_term = tripal_get_chado_semweb_term('db', 'name');
+    //    $accession_term = tripal_get_chado_semweb_term('dbxref', 'accession');
+    //    $dburl_term = tripal_get_chado_semweb_term('db', 'url');
+    //
+    //    // Set some defaults for the empty record.
+    //    $entity->{$field_name}['und'][0] = [
+    //      'value' => '',
+    //      'chado-' . $field_table . '__' . $pkey => '',
+    //      'chado-' . $field_table . '__' . $fkey_lcolumn => $record->$fkey_rcolumn,
+    //      'chado-' . $field_table . '__dbxref_id' => '',
+    //      'db_id' => '',
+    //      'accession' => '',
+    //    ];
+    //
+    //    $linker_table = $base_table . '_dbxref';
+    //    $options = ['return_array' => 1];
+    //    dpm($record);
+    //    dpm(chado_expand_var($record, 'table', $linker_table, $options));
+    //    $record = chado_expand_var($record, 'table', $linker_table, $options);
+    //
+    //
+    //    $i = 0;
+    //
+    //    if (count($record->$linker_table) > 0) {
+    //      foreach ($record->$linker_table as $index => $linker) {
+    //        $dbxref = $linker->dbxref_id;
+    //
+    //        // Ignore the GFF_source database. This is a weird thing required by
+    //        // GBrowse and is added by the GFF loader. We don't want to show it.
+    //        if ($dbxref->db_id->name == 'GFF_source') {
+    //          continue;
+    //        }
+    //
+    //        $URL = tripal_get_dbxref_url($dbxref);
+    //        $entity->{$field_name}['und'][$i] = [
+    //          'value' => [
+    //            $dbname_term => $dbxref->db_id->name,
+    //            $accession_term => $dbxref->accession,
+    //            $dburl_term => $URL,
+    //          ],
+    //          'chado-' . $field_table . '__' . $pkey => $linker->$pkey,
+    //          'chado-' . $field_table . '__' . $fkey_lcolumn => $linker->$fkey_lcolumn->$fkey_lcolumn,
+    //          'chado-' . $field_table . '__dbxref_id' => $dbxref->dbxref_id,
+    //          'db_id' => $dbxref->db_id->db_id,
+    //          'accession' => $dbxref->accession,
+    //
+    //        ];
+    //        $i++;
+    //      }
+    //    }
+    //  }
+  }
+}

--- a/tripal_biomaterial/includes/TripalFields/sio__primary_cross_reference/sio__primary_cross_reference_formatter.inc
+++ b/tripal_biomaterial/includes/TripalFields/sio__primary_cross_reference/sio__primary_cross_reference_formatter.inc
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Display:
+ * Configuration:
+ */
+class sio__primary_cross_reference_formatter extends ChadoFieldFormatter {
+
+  // The default label for this field.
+  public static $default_label = 'primary cross reference';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('sio__primary_cross_reference');
+
+  // The list of default settings for this formatter.
+  public static $default_settings = array(
+    'setting1' => 'default_value',
+  );
+
+  /**
+   * Provides the field's setting form.
+   *
+   * This function corresponds to the hook_field_formatter_settings_form()
+   * function of the Drupal Field API.
+   *
+   * The settings form appears on the 'Manage Display' page of the content
+   * type administration page. This function provides the form that will
+   * appear on that page.
+   *
+   * To add a validate function, please create a static function in the
+   * implementing class, and indicate that this function should be used
+   * in the form array that is returned by this function.
+   *
+   * This form will not be displayed if the formatter_settings_summary()
+   * function does not return anything.
+   *
+   * param $field
+   *   The field structure being configured.
+   * param $instance
+   *   The instance structure being configured.
+   * param $view_mode
+   *   The view mode being configured.
+   * param $form
+   *   The (entire) configuration form array, which will usually have no use
+   *   here.  Typically for reference only.
+   * param $form_state
+   *   The form state of the (entire) configuration form.
+   *
+   * @return
+   *   A Drupal Form array containing the settings form for this field.
+   */
+  public function settingsForm($view_mode, $form, &$form_state) {
+
+  }
+
+  /**
+   *  Provides the display for a field
+   *
+   * This function corresponds to the hook_field_formatter_view()
+   * function of the Drupal Field API.
+   *
+   *  This function provides the display for a field when it is viewed on
+   *  the web page.  The content returned by the formatter should only include
+   *  what is present in the $items[$delta]['values] array. This way, the
+   *  contents that are displayed on the page, via webservices and downloaded
+   *  into a CSV file will always be identical.  The view need not show all
+   *  of the data in the 'values' array.
+   *
+   *  @param $element
+   *  @param $entity_type
+   *  @param $entity
+   *  @param $langcode
+   *  @param $items
+   *  @param $display
+   *
+   *  @return
+   *    An element array compatible with that returned by the
+   *    hook_field_formatter_view() function.
+   */
+  public function view(&$element, $entity_type, $entity, $langcode, $items, $display) {
+
+    // Get the settings
+    $settings = $display['settings'];
+    dpm($items);
+    
+  }
+
+  /**
+   * Provides a summary of the formatter settings.
+   *
+   * This function corresponds to the hook_field_formatter_settings_summary()
+   * function of the Drupal Field API.
+   *
+   * On the 'Manage Display' page of the content type administration page,
+   * fields are allowed to provide a settings form.  This settings form can
+   * be used to allow the site admin to define how the field should be
+   * formatted.  The settings are then available for the formatter()
+   * function of this class.  This function provides a text-based description
+   * of the settings for the site developer to see.  It appears on the manage
+   * display page inline with the field.  A field must always return a
+   * value in this function if the settings form gear button is to appear.
+   *
+   * See the hook_field_formatter_settings_summary() function for more
+   * information.
+   *
+   * @param $field
+   * @param $instance
+   * @param $view_mode
+   *
+   * @return string
+   *   A string that provides a very brief summary of the field settings
+   *   to the user.
+   *
+   */
+  public function settingsSummary($view_mode) {
+    return '';
+  }
+
+}

--- a/tripal_biomaterial/includes/TripalFields/sio__primary_cross_reference/sio__primary_cross_reference_widget.inc
+++ b/tripal_biomaterial/includes/TripalFields/sio__primary_cross_reference/sio__primary_cross_reference_widget.inc
@@ -1,0 +1,122 @@
+<?php
+/**
+ * @class
+ * Purpose:
+ *
+ * Allowing edit?
+ * Data:
+ * Assumptions:
+ */
+class sio__primary_cross_reference_widget extends ChadoFieldWidget {
+
+  // The default label for this field.
+  public static $default_label = 'primary cross reference';
+
+  // The list of field types for which this formatter is appropriate.
+  public static $field_types = array('sio__primary_cross_reference');
+
+  /**
+   * Provides the form for editing of this field.
+   *
+   * This function corresponds to the hook_field_widget_form()
+   * function of the Drupal Field API.
+   *
+   * This form is diplayed when the user creates a new entity or edits an
+   * existing entity.  If the field is attached to the entity then the form
+   * provided by this function will be displayed.
+   *
+   * At a minimum, the form must have a 'value' element.  For Tripal, the
+   * 'value' element of a field always corresponds to the value that is
+   * presented to the end-user either directly on the page (with formatting)
+   * or via web services, or some other mechanism.  However, the 'value' is
+   * sometimes not enough for a field.  For example, the Tripal Chado module
+   * maps fields to table columns and sometimes those columns are foreign keys
+   * therefore, the Tripal Chado modules does not just use the 'value' but adds
+   * additional elements to help link records via FKs.  But even in this case
+   * the 'value' element must always be present in the return form and in such
+   * cases it's value should be set equal to that added in the 'load' function.
+   *
+   * @param $widget
+   * @param $form
+   *   The form structure where widgets are being attached to. This might be a
+   *   full form structure, or a sub-element of a larger form.
+   * @param $form_state
+   *   An associative array containing the current state of the form.
+   * @param $langcode
+   *   The language associated with $items.
+   * @param $items
+   *   Array of default values for this field.
+   * @param $delta
+   *   The order of this item in the array of subelements (0, 1, 2, etc).
+   * @param $element
+   * A form element array containing basic properties for the widget:
+   *  - #entity_type: The name of the entity the field is attached to.
+   *  - #bundle: The name of the field bundle the field is contained in.
+   *  - #field_name: The name of the field.
+   *  - #language: The language the field is being edited in.
+   *  - #field_parents: The 'parents' space for the field in the form. Most
+   *    widgets can simply overlook this property. This identifies the location
+   *    where the field values are placed within $form_state['values'], and is
+   *    used to access processing information for the field through the
+   *    field_form_get_state() and field_form_set_state() functions.
+   *  - #columns: A list of field storage columns of the field.
+   *  - #title: The sanitized element label for the field instance, ready for
+   *    output.
+   *  - #description: The sanitized element description for the field instance,
+   *    ready for output.
+   *  - #required: A Boolean indicating whether the element value is required;
+   *    for required multiple value fields, only the first widget's values are
+   *    required.
+   *  - #delta: The order of this item in the array of subelements; see
+   *    $delta above
+   */
+  public function form(&$widget, &$form, &$form_state, $langcode, $items, $delta, $element) {
+    parent::form($widget, $form, $form_state, $langcode, $items, $delta, $element);
+  }
+
+  /**
+   * Performs validation of the widgetForm.
+   *
+   * Use this validate to ensure that form values are entered correctly.
+   * The 'value' key of this field must be set in the $form_state['values']
+   * array anytime data is entered by the user.  It may be the case that there
+   * are other fields for helping select a value. In the end those helper
+   * fields must be used to set the 'value' field.
+   */
+  public function validate($element, $form, &$form_state, $langcode, $delta) {
+  }
+
+  /**
+   * Performs extra commands when the entity form is submitted.
+   *
+   * Drupal typically does not provide a submit hook for fields.  The
+   * TripalField provides one to allow for behind-the-scenes actions to
+   * occur.   This function should never be used for updates, deletes or
+   * inserts for the Chado table associated with the field.  Rather, the
+   * storage backend should be allowed to handle inserts, updates deletes.
+   * However, it is permissible to perform inserts, updates or deletions within
+   * Chado using this function.  Those operations can be performed if needed but
+   * on other tables not directly associated with the field.
+   *
+   * An example is the chado.feature_synonym table.  The chado_linker__synonym
+   * field allows the user to provide a brand new synonynm and it must add it
+   * to the chado.synonym table prior to the record in the
+   * chado.feature_synonym table.  This insert occurs in the widgetFormSubmit
+   * function.
+   *
+   * @param $form
+   *    The submitted form array.
+   * @param $form_state .
+   *    The form state array.
+   * @param $entity_type
+   *    The type of $entity.
+   * @param $entity
+   *    The entity for the operation.
+   * @param $langcode
+   *    The language associated with $items.
+   * @param $delta
+   */
+  public function submit($form, &$form_state, $entity_type, $entity, $langcode, $delta) {
+  }
+
+}

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -348,12 +348,9 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     $comment = $biosample->Description->Comment->Paragraph;
     $ncbi_owner = $biosample->Owner->Name;
 
-    //$biomaterial_provider = $biosample->Attributes->Attribute[1];
-
     $biomaterial_provider = $biosample->Owner->Contacts->Contact->Name;
 
     // Create a contact if contact is not present.
-
     if ($biomaterial_provider) {
       $contact_name = "";
       if ($biomaterial_provider->Last && $biomaterial_provider->First) {
@@ -386,6 +383,9 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     ]);
     $dbxref_biosample_id = $dbxref_biosample->dbxref_id;
 
+
+    //note:  this dbxref (ncbi biosample) previously was insert into the biomaterial table.  This is incorrect: t his column is only for INTERNAL accessions.
+
     // If sra_accession is present, create entry in the dbxref table.
     if ($sra_accession) {
       $dbxref_sra = tripal_insert_dbxref([
@@ -399,7 +399,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
     $biomaterial_description = $comment ? (string) $comment : (string) $description;
 
-    $biomaterial_id = tripal_biomaterial_create_biomaterial($unique_name, $analysis_id, $organism_id, $biosourceprovider_id, $dbxref_biosample_id, $biomaterial_description);
+    $biomaterial_id = tripal_biomaterial_create_biomaterial($unique_name, $analysis_id, $organism_id, $biosourceprovider_id, $biomaterial_description);
 
     // Add to biomaterialprop table.
     $this->add_xml_biomaterial_properties($biosample->Attributes->Attribute, $biomaterial_id, $insert_fields);
@@ -411,6 +411,15 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         'db_name' => 'NCBI SRA',
       ]);
     }
+    //Also add the NCBI BioSample DBXREF previously inserted into the biomaterial table
+    if ($sample_accession){
+      tripal_associate_dbxref('biomaterial', $biomaterial_id, [
+        'accession'=> $sample_accession,
+        'db_name' => 'NCBI BioSample'
+      ]);
+
+    }
+
   }
 
   /**

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -635,20 +635,10 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
           if ($name == 'biomaterial_provider' and $line[$index] != "") {
             $biosourceprovider_id = tripal_biomaterial_create_biomaterial_contact($line[$index]);
           }
-          if ($name == 'biosample_accession') {
-            // In case there is no biosample database
-            $ncbi_biosample_id = tripal_biomaterial_create_ncbi_db('biosample', 'NCBI BioSample', '');
-            $values = [
-              'accession' => $line[$index],
-              'db_id' => $ncbi_biosample_id,
-            ];
-            $dbxref = chado_insert_record('dbxref', $values);
-            $dbxref_id = $dbxref->dbxref_id;
-          }
         }
 
         // Create the biomaterial based on the values given.
-        $biomaterial_id = tripal_biomaterial_create_biomaterial($unique_name, $analysis_id, $organism_id, $biosourceprovider_id, $dbxref_id, $description);
+        $biomaterial_id = tripal_biomaterial_create_biomaterial($unique_name, $analysis_id, $organism_id, $biosourceprovider_id, $description);
 
         // Insert database accessions.
         foreach ($acc_headers as $name => $index) {
@@ -656,6 +646,10 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
           if ($name == 'sra_accession') {
             $db_id = tripal_biomaterial_create_ncbi_db('sra', 'NCBI SRA', '');
           }
+          elseif ($name == 'biosample_accession') {
+              // In case there is no biosample database
+              $db_id = tripal_biomaterial_create_ncbi_db('biosample', 'NCBI BioSample', '');
+            }
           else {
             if ($name == 'bioproject_accession') {
               $db_id = tripal_biomaterial_create_ncbi_db('bioproject', 'NCBI BioProject', '');


### PR DESCRIPTION
Resolves #152.  see 
https://github.com/statonlab/hardwoods_site/issues/31 and https://github.com/tripal/tripal/issues/231

Instead of inserting the accession into `biomaterial` we associate it like we do the other db's in `biomaterial_dbxref`.

Note that we need to do something for already loaded bio samples.


