### PR TITLE
Ctarget

### DIFF
--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -343,19 +343,36 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
         $row = [$cvt_name, $cv_name, $db_name, $accession, $cvt_def];
         $rows[$cv_name] = $row;
+
+
+
+        $info = [
+          'cvt_name' => $cvt_name,
+          'cv_name' => $cv_name,
+          'db_name' => $db_name,
+          'cvt_accession' => $accession,
+          'cvt_id' => $cvt_id,
+        ];
+
+        //stick the info in the form so we can match it up later
+        $form['cvterms']['cvalue_configuration'][$property_value][$cv_name] = [
+          '#type' => 'value',
+          '#value' => $info,
+        ];
+
       }
 
       //if no rows then the term isn't in DB.
 
       if (!$rows) {
         $markup = "<p>There is no cvterm in the Chado database matching the property <b>$property_value</b>.  You can insert a term and try again, or submit not use a cvterm for this property value.</p>";
-        $form['cvterms']['cvalue_configuration'][$property_value]['cv_table'] = [
+        $form['cvterms']['cvalue_configuration'][$property_value]['choose'] = [
           '#markup' => $markup,
         ];
       }
       else {
 
-        $form['cvterms']['cvalue_configuration'][$property_value]['cv_table'] = [
+        $form['cvterms']['cvalue_configuration'][$property_value]['choose'] = [
           '#type' => 'tableselect',
           '#header' => $header,
           '#options' => $rows,
@@ -371,9 +388,6 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
    * @see TripalImporter::formValidate()
    */
   public function formValidate($form, &$form_state) {
-    dpm($form_state);
-
-
   }
 
   /**
@@ -404,16 +418,19 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       tripal_set_message("Warning: properties not configured.  Using generic cvterms for all properties.", TRIPAL_WARNING);
     }
 
+    $insert_cvalues  = [];
 
-    $insert_cvalues = [];
+    if ($cvalue_info){
+      foreach($cvalue_info as $cvalue_label => $property){
 
-    foreach ($field_info as $property_label => $property) {
-
-      $selected_cv_info = $property[$selected_cv];
-      $insert_cvalues[$property_label] = $selected_cv_info;
-
+        $selected_cv = $property['choose'];
+        print($selected_cv);
+        if ($selected_cv) {
+          $selected_cv_info = $property[$selected_cv];
+          $insert_cvalues[$cvalue_label] = $selected_cv_info['cvt_id'];
+        }
+      }
     }
-
 
     $extension = explode('.', $file_path);
     $extension = $extension[count($extension) - 1];
@@ -680,14 +697,8 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
       $cvalue_id = NULL;
 
-
       if (isset($insert_cvalues[$value])) {
-        $specified_cvalue_cv_id = $insert_cvalues[$value];
-        $cvalue_term = tripal_get_cvterm(['cvterm_id' => $specified_cvalue_cv_id]);
-        if (!$cvalue_term) {
-          print "ERROR: Invalid target CVterm provided for " . $value;
-          exit;
-        }
+        $cvalue_id = $insert_cvalues[$value];
       }
 
       // Insert the property into the biomaterialprop table.

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -154,12 +154,28 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     }
 
 
-    $form['cvterm_configuration'] = [
+    $form['cvterms'] = [
+      '#type' => 'fieldset',
+      '#prefix' => '<div id="cvterm_configuration_div">',
+      '#suffix' => '</div>',
+    ];
+
+    $form['cvterms']['cvterm_configuration'] = [
       '#type' => 'fieldset',
       '#title' => t('CVterm Field Configuration'),
       '#description' => $description,
-      '#prefix' => '<div id="cvterm_configuration_div">',
-      '#suffix' => '</div>',
+
+      '#tree' => TRUE,
+    ];
+
+
+    $description = t('This section will allow you to check the CVterms associated with your biomaterial property <b>values</b>.  FOr example, if your property was "color", the property value might be "red".</a>');
+
+
+    $form['cvterms']['cvalue_configuration'] = [
+      '#type' => 'fieldset',
+      '#title' => t('CVterm Value Configuration'),
+      '#description' => $description,
       '#tree' => TRUE,
     ];
 
@@ -204,7 +220,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $description .= '"' . $subfield . '"' . "  ";
       }
 
-      $form['cvterm_configuration'][$field_label] = [
+      $form['cvterms']['cvterm_configuration'][$field_label] = [
         '#type' => 'fieldset',
         '#title' => t($field_label),
         '#collapsible' => TRUE,
@@ -212,14 +228,20 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         '#description' => $description,
       ];
 
-      $header = ["CVterm name",  "CV name", "DB name", "Accession", "CVterm definition"];
+      $header = [
+        "CVterm name",
+        "CV name",
+        "DB name",
+        "Accession",
+        "CVterm definition",
+      ];
 
       $rows = [];
       foreach ($cv_array as $cv_name => $field_term) {
         $db_name = $field_term["db"];
         $accession = $field_term["accession"];
-        $cvt_name = $cv_array[$cv_name]["cvt_name"] ;
-        $cvt_def = $cv_array[$cv_name]["cvt_def"] ;
+        $cvt_name = $cv_array[$cv_name]["cvt_name"];
+        $cvt_def = $cv_array[$cv_name]["cvt_def"];
 
         $row = [$cvt_name, $cv_name, $db_name, $accession, $cvt_def];
         $rows[$cv_name] = $row;
@@ -229,13 +251,13 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
       if (!$rows) {
         $markup = "<p>There is no cvterm in the Chado database matching the property <b>$field_label</b>.  You can insert a term and try again, or submit and use a generic cv.</p>";
-        $form['cvterm_configuration'][$field_label]['cv_table'] = [
+        $form['cvterms']['cvterm_configuration'][$field_label]['cv_table'] = [
           '#markup' => $markup,
         ];
       }
       else {
 
-        $form['cvterm_configuration'][$field_label]['cv_table'] = [
+        $form['cvterms']['cvterm_configuration'][$field_label]['cv_table'] = [
           '#type' => 'tableselect',
           '#header' => $header,
           '#options' => $rows,
@@ -245,23 +267,80 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     }
 
 
-    $description = t('This section will allow you to check the CVterms associated with your biomaterial property <b>values</b>.  FOr example, if your property was "color", the property value might be "red".</a>');
+    //now do almost the same thing for property values.  Oops.
+    //TODO refactor these since we do it 2x
+    foreach ($property_values as $property_value) {
 
+      $cv_array = [];
 
-    $form['cvalue_configuration'] = [
-      '#type' => 'fieldset',
-      '#title' => t('CVterm Value Configuration'),
-      '#description' => $description,
-      '#prefix' => '<div id="cvterm_configuration_div">',
-      '#suffix' => '</div>',
-      '#tree' => TRUE,
-    ];
+      //Get terms
+      $sql = "SELECT CV.name AS cv_name, DB.name AS db_name, DBX.accession AS dbx_accession, CVT.name AS cvt_name, CVT.definition AS cvt_def FROM {cvterm} AS CVT
+              INNER JOIN {CV} AS CV ON CVT.cv_id = CV.cv_id
+              INNER JOIN {dbxref} as DBX ON CVT.dbxref_id = DBX.dbxref_id
+              INNER JOIN {db} as DB ON DBX.db_id = DB.db_id
+              WHERE CVT.name  = :field";
 
+      $prop_result = chado_query($sql, [":field" => $property_value])->fetchAll();
 
+      foreach ($prop_result as $field_term) {
+        $cv_name = $field_term->cv_name;
+        $db_name = $field_term->db_name;
+        $accession = $field_term->dbx_accession;
+        $cvt_name = $field_term->cvt_name;
+        $cvt_def = $field_term->cvt_def;
 
-    foreach ($property_values as $property_value){
+        $cv_array[$cv_name]["cv"] = $cv_name;
+        $cv_array[$cv_name]["db"] = $db_name;
+        $cv_array[$cv_name]["accession"] = $accession;
+        $cv_array[$cv_name]["cvt_name"] = $cvt_name;
+        $cv_array[$cv_name]["cvt_name"] = $cvt_def;
 
-      dpm($property_value);
+      }
+
+      $form['cvterms']['cvalue_configuration'][$property_value] = [
+        '#type' => 'fieldset',
+        '#title' => t($property_value),
+        '#collapsible' => TRUE,
+        '#collapsed' => FALSE,
+      ];
+
+      $header = [
+        "CVterm name",
+        "CV name",
+        "DB name",
+        "Accession",
+        "CVterm definition",
+      ];
+
+      $rows = [];
+      foreach ($cv_array as $cv_name => $field_term) {
+        $db_name = $field_term["db"];
+        $accession = $field_term["accession"];
+        $cvt_name = $cv_array[$cv_name]["cvt_name"];
+        $cvt_def = $cv_array[$cv_name]["cvt_def"];
+
+        $row = [$cvt_name, $cv_name, $db_name, $accession, $cvt_def];
+        $rows[$cv_name] = $row;
+      }
+
+      //if no rows then the term isn't in DB.
+
+      if (!$rows) {
+        $markup = "<p>There is no cvterm in the Chado database matching the property <b>$property_value</b>.  You can insert a term and try again, or submit not use a cvterm for this property value.</p>";
+        $form['cvterms']['cvalue_configuration'][$property_value]['cv_table'] = [
+          '#markup' => $markup,
+        ];
+      }
+      else {
+
+        $form['cvterms']['cvalue_configuration'][$property_value]['cv_table'] = [
+          '#type' => 'tableselect',
+          '#header' => $header,
+          '#options' => $rows,
+          '#multiple' => FALSE,
+        ];
+      }
+
 
     }
 
@@ -1040,5 +1119,6 @@ function test_biosample_cvterms_flat(
  */
 
 function cvterm_validator_callback(&$form, &$form_state) {
-  return $form['class_elements']['cvterm_configuration'];
+ // return $form['class_elements']['cvterm_configuration'];
+  return $form['class_elements']['cvterms'];
 }

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -118,6 +118,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     ];
 
     $fields = [];
+    $property_values =[];
 
     $description = t('After submitting uploading your file(s) and clicking the Check Biosamples button, you can configure individual cvterms for your biomaterial properties here.');
 
@@ -293,7 +294,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $cv_array[$cv_name]["db"] = $db_name;
         $cv_array[$cv_name]["accession"] = $accession;
         $cv_array[$cv_name]["cvt_name"] = $cvt_name;
-        $cv_array[$cv_name]["cvt_name"] = $cvt_def;
+        $cv_array[$cv_name]["cvt_def"] = $cvt_def;
 
       }
 
@@ -364,11 +365,11 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     $organism_id = $arguments['organism_id'];
     $analysis_id = $arguments['analysis_id'];
     $field_info = $arguments['cvterm_configuration'];
+    $cvalue_info = $arguments['cvalue_configuration'];
 
     //generate list of cvterm properties to associate with each field
     // if one wasnt selected, key wont exist and we'll insert into biomaterialprop
     $insert_fields = [];
-
     if ($field_info) {
       foreach ($field_info as $field => $cv_table) {
         $chosen_cv = implode(($cv_table));
@@ -379,16 +380,27 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       tripal_set_message("Warning: properties not configured.  Using generic cvterms for all properties.", TRIPAL_WARNING);
     }
 
+    $insert_cvalues = [];
+    //TODO: THIS SHOUDL GET THE CVTERM_IDNOT THE CV ID
+    if ($cvalue_info) {
+      foreach ($cvalue_info as $cvalue => $cv_table){
+        $chosen_cv = implode($cv_table);
+        $insert_cvalues[$cvalue] = $chosen_cv;
+      }
+    }
+
+
+
     $extension = explode('.', $file_path);
     $extension = $extension[count($extension) - 1];
 
     tripal_set_message(t("Job Submitted!  After running the job, remember to") . l('publish the inserted BioSamples.', 'admin/content/bio_data/publish/'), TRIPAL_INFO);
 
     if ($extension == "xml") {
-      $this->load_biosample_xml($file_path, $organism_id, $analysis_id, $insert_fields);
+      $this->load_biosample_xml($file_path, $organism_id, $analysis_id, $insert_fields, $insert_cvalues);
     }
     else {
-      $this->load_biosample_flat($file_path, $organism_id, $analysis_id, $insert_fields);
+      $this->load_biosample_flat($file_path, $organism_id, $analysis_id, $insert_fields, $insert_cvalues);
     }
   }
 
@@ -401,7 +413,9 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     $file_path,
     $organism_id,
     $analysis_id,
-    $insert_fields
+    $insert_fields,
+  $insert_cvalues
+
   ) {
 
     // Check file path to see if file is accessible.nsaction = db_transaction();
@@ -457,7 +471,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       // Load biomaterials.
       for ($i = 0; $i < $num_biosamples; $i++) {
         print "Loading BioSample " . ($i + 1) . " of " . $num_biosamples . "\n";
-        $this->add_xml_data($organism_id, $xml->BioSample[$i], $analysis_id, $insert_fields);
+        $this->add_xml_data($organism_id, $xml->BioSample[$i], $analysis_id, $insert_fields, $insert_cvalues);
       }
     } catch (Exception $e) {
       print "\n";
@@ -472,12 +486,17 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
   /**
    * @param $organism_id
    * @param $biosample
+   * @param $analysis_id
+   * @param $insert_fields
+   * @param $insert_cvalues - the cvalues to associate with the biomaterialprop.  Use this in addition to the property text value.
    */
+
   protected function add_xml_data(
     $organism_id,
     $biosample,
     $analysis_id,
-    $insert_fields
+    $insert_fields,
+    $insert_cvalues
   ) {
 
     // Extract data from the xml string.
@@ -546,7 +565,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     $biomaterial_id = tripal_biomaterial_create_biomaterial($unique_name, $analysis_id, $organism_id, $biosourceprovider_id, $dbxref_id, $biomaterial_description);
 
     // Add to biomaterialprop table.
-    $this->add_xml_biomaterial_properties($biosample->Attributes->Attribute, $biomaterial_id, $insert_fields);
+    $this->add_xml_biomaterial_properties($biosample->Attributes->Attribute, $biomaterial_id, $insert_fields, $insert_cvalues);
 
     // Add to biomaterial_dbxref table.
     if ($sra_accession) {
@@ -573,7 +592,8 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
   protected function add_xml_biomaterial_properties(
     $attributes,
     $biomaterial_id,
-    $insert_fields
+    $insert_fields,
+    $insert_cvalues
   ) {
 
     $record = [
@@ -604,6 +624,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       $cv_name = 'biomaterial_property';
       if (isset($insert_fields[$attr_name])) {
         $specified_cv = $insert_fields[$attr_name];
+
       }
       if ($specified_cv) {
         $cv_name = $specified_cv;
@@ -621,15 +642,33 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         }
       }
 
+      //TODO: test for cvalue
+
+      $cvalue_id = null;
+
+      if (isset($insert_cvalues[$value])){
+        $specified_cvalue_cv_id = $insert_cvalues[$value];
+        //TODO look up this term in this CV
+
+        $specified_cvalue_cvterm = chado_cvterm
+
+      }
+
+
+      //TODO: WE ALLOWED THE CVTERM FOR THE PROPERTY TO NO LONGER MATCH THE PROPERTY NAME (IE CASES WHERE THE HUMAN READABLE NAME WAS BETTER ETC).  HOW DO WE RECONCILE THIS?
+
       // Insert the property into the biomaterialprop table.
       $property = [
         'type_name' => $attr_name,
         'cv_name' => $cv_name,
         'value' => $value,
+        'cvalue_id' => $cvalue_id
       ];
       chado_insert_property($record, $property, $options);
     }
   }
+
+
 
   /**
    * @param $file_path
@@ -982,7 +1021,7 @@ function test_xml_data(
 ) {
 
   //get xml attributes
-  //dont get ocnfused here-> we actually look for a node called "attributes" with child node "attribute"
+  //dont get confused here-> we actually look for a node called "attributes" with child node "attribute"
   $attributes = $biosample->Attributes->Attribute;
   foreach ($attributes as $key => $attribute_object) {
 
@@ -1103,7 +1142,8 @@ function test_biosample_cvterms_flat(
     if ($header == 'bioproject_accession') {
     }
     else {
-      $attribute_list[] = $header;
+      //values
+      $attribute_list[]["attributes"] = $header;
     }
   }
   return ($attribute_list);
@@ -1119,6 +1159,5 @@ function test_biosample_cvterms_flat(
  */
 
 function cvterm_validator_callback(&$form, &$form_state) {
- // return $form['class_elements']['cvterm_configuration'];
   return $form['class_elements']['cvterms'];
 }

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -345,7 +345,6 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $rows[$cv_name] = $row;
 
 
-
         $info = [
           'cvt_name' => $cvt_name,
           'cv_name' => $cv_name,
@@ -418,10 +417,10 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       tripal_set_message("Warning: properties not configured.  Using generic cvterms for all properties.", TRIPAL_WARNING);
     }
 
-    $insert_cvalues  = [];
+    $insert_cvalues = [];
 
-    if ($cvalue_info){
-      foreach($cvalue_info as $cvalue_label => $property){
+    if ($cvalue_info) {
+      foreach ($cvalue_info as $cvalue_label => $property) {
 
         $selected_cv = $property['choose'];
         print($selected_cv);
@@ -675,8 +674,6 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $specified_prop_db = $insert_fields[$attr_name]['db_name'];
         $specified_prop_accession = $insert_fields[$attr_name]['cvt_accession'];
         $specified_prop_cvterm = $insert_fields[$attr_name]['cvt_name'];
-
-
         $cv_name = $specified_prop_cv;
         $attr_name = $specified_prop_cvterm;//we rename the attribute here, in case we chose a cvterm whose name is different from the attribute in the XML.
 
@@ -718,13 +715,13 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
    * @param $organism_id
    * @param $analysis_id
    * @param $file_type
-   * @param $flat_file_type
    */
   protected function load_biosample_flat(
     $file_path,
     $organism_id,
     $analysis_id,
-    $insert_fields
+    $insert_fields,
+    $insert_cvalues
   ) {
     try {
       if (!is_readable($file_path)) {
@@ -946,10 +943,19 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
               'table' => 'biomaterial',
               'id' => $biomaterial_id,
             ];
+
+            $cvalue_id = NULL;
+            $cvalue_text = $line[$index];
+
+            if ($insert_cvalues[$cvalue_text]){
+              $cvalue_id = $insert_cvalues[$cvalue_text];
+            }
+
             $property = [
               'type_name' => $name,
               'cv_name' => $cv_name,
-              'value' => $line[$index],
+              'value' => $cvalue_text,
+              'cvalue_id' => $cvalue_id
             ];
             $options = [
               'update_if_present' => TRUE,
@@ -1185,8 +1191,11 @@ function test_biosample_cvterms_flat(
     if ($header == 'bioproject_accession') {
     }
     else {
-      //values
       $attribute_list[]["attributes"] = $header;
+
+      //TODO: this is where the flat file loader would support checking the cvalues as well
+      $attribute_list[]["values"] = null;
+
     }
   }
   return ($attribute_list);

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -118,7 +118,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     ];
 
     $fields = [];
-    $property_values =[];
+    $property_values = [];
 
     $description = t('After submitting uploading your file(s) and clicking the Check Biosamples button, you can configure individual cvterms for your biomaterial properties here.');
 
@@ -191,7 +191,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
 
       //Get terms
-      $sql = "SELECT CV.name AS cv_name, DB.name AS db_name, DBX.accession AS dbx_accession, CVT.name AS cvt_name, CVT.definition AS cvt_def FROM {cvterm} AS CVT
+      $sql = "SELECT CV.name AS cv_name, DB.name AS db_name, DBX.accession AS dbx_accession, CVT.name AS cvt_name, CVT.definition AS cvt_def, CVT.cvterm_id AS cvt_id FROM {cvterm} AS CVT
               INNER JOIN {CV} AS CV ON CVT.cv_id = CV.cv_id
               INNER JOIN {dbxref} as DBX ON CVT.dbxref_id = DBX.dbxref_id
               INNER JOIN {db} as DB ON DBX.db_id = DB.db_id
@@ -205,12 +205,14 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $accession = $field_term->dbx_accession;
         $cvt_name = $field_term->cvt_name;
         $cvt_def = $field_term->cvt_def;
+        $cvt_id = $field_term->cvt_id;
 
         $cv_array[$cv_name]["cv"] = $cv_name;
         $cv_array[$cv_name]["db"] = $db_name;
         $cv_array[$cv_name]["accession"] = $accession;
         $cv_array[$cv_name]["cvt_name"] = $cvt_name;
-        $cv_array[$cv_name]["cvt_name"] = $cvt_def;
+        $cv_array[$cv_name]["cvt_def"] = $cvt_def;
+        $cv_array[$cv_name]["cvt_id"] = $cvt_id;
 
       }
 
@@ -243,8 +245,25 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $accession = $field_term["accession"];
         $cvt_name = $cv_array[$cv_name]["cvt_name"];
         $cvt_def = $cv_array[$cv_name]["cvt_def"];
+        $cvt_id = $cv_array[$cv_name]["cvt_id"];
+
 
         $row = [$cvt_name, $cv_name, $db_name, $accession, $cvt_def];
+
+        $info = [
+          'cvt_name' => $cvt_name,
+          'cv_name' => $cv_name,
+          'db_name' => $db_name,
+          'cvt_accession' => $accession,
+          'cvt_id' => $cvt_id,
+        ];
+
+        //stick the info in the form so we can match it up later
+        $form['cvterms']['cvterm_configuration'][$field_label][$cv_name] = [
+          '#type' => 'value',
+          '#value' => $info,
+        ];
+
         $rows[$cv_name] = $row;
       }
 
@@ -252,13 +271,13 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
       if (!$rows) {
         $markup = "<p>There is no cvterm in the Chado database matching the property <b>$field_label</b>.  You can insert a term and try again, or submit and use a generic cv.</p>";
-        $form['cvterms']['cvterm_configuration'][$field_label]['cv_table'] = [
+        $form['cvterms']['cvterm_configuration'][$field_label] = [
           '#markup' => $markup,
         ];
       }
       else {
 
-        $form['cvterms']['cvterm_configuration'][$field_label]['cv_table'] = [
+        $form['cvterms']['cvterm_configuration'][$field_label]['choose'] = [
           '#type' => 'tableselect',
           '#header' => $header,
           '#options' => $rows,
@@ -275,7 +294,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       $cv_array = [];
 
       //Get terms
-      $sql = "SELECT CV.name AS cv_name, DB.name AS db_name, DBX.accession AS dbx_accession, CVT.name AS cvt_name, CVT.definition AS cvt_def FROM {cvterm} AS CVT
+      $sql = "SELECT CV.name AS cv_name, DB.name AS db_name, DBX.accession AS dbx_accession, CVT.name AS cvt_name, CVT.definition AS cvt_def, CVT.cvterm_id AS cvt_id  FROM {cvterm} AS CVT
               INNER JOIN {CV} AS CV ON CVT.cv_id = CV.cv_id
               INNER JOIN {dbxref} as DBX ON CVT.dbxref_id = DBX.dbxref_id
               INNER JOIN {db} as DB ON DBX.db_id = DB.db_id
@@ -295,6 +314,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $cv_array[$cv_name]["accession"] = $accession;
         $cv_array[$cv_name]["cvt_name"] = $cvt_name;
         $cv_array[$cv_name]["cvt_def"] = $cvt_def;
+        $cv_array[$cv_name]["cvt_id"] = $field_term->cvt_id;
 
       }
 
@@ -319,6 +339,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $accession = $field_term["accession"];
         $cvt_name = $cv_array[$cv_name]["cvt_name"];
         $cvt_def = $cv_array[$cv_name]["cvt_def"];
+        $cvt_id = $cv_array[$cv_name]["cvt_id"];
 
         $row = [$cvt_name, $cv_name, $db_name, $accession, $cvt_def];
         $rows[$cv_name] = $row;
@@ -341,8 +362,6 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
           '#multiple' => FALSE,
         ];
       }
-
-
     }
 
     return $form;
@@ -352,6 +371,8 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
    * @see TripalImporter::formValidate()
    */
   public function formValidate($form, &$form_state) {
+    dpm($form_state);
+
 
   }
 
@@ -371,24 +392,27 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     // if one wasnt selected, key wont exist and we'll insert into biomaterialprop
     $insert_fields = [];
     if ($field_info) {
-      foreach ($field_info as $field => $cv_table) {
-        $chosen_cv = implode(($cv_table));
-        $insert_fields[$field] = $chosen_cv;
+      foreach ($field_info as $property_label => $property) {
+        $selected_cv = $property['choose'];
+        $selected_cv_info = $property[$selected_cv];
+        if ($selected_cv) {
+          $insert_fields[$property_label] = $selected_cv_info;
+        }
       }
     }
     else {
       tripal_set_message("Warning: properties not configured.  Using generic cvterms for all properties.", TRIPAL_WARNING);
     }
 
-    $insert_cvalues = [];
-    //TODO: THIS SHOUDL GET THE CVTERM_IDNOT THE CV ID
-    if ($cvalue_info) {
-      foreach ($cvalue_info as $cvalue => $cv_table){
-        $chosen_cv = implode($cv_table);
-        $insert_cvalues[$cvalue] = $chosen_cv;
-      }
-    }
 
+    $insert_cvalues = [];
+
+    foreach ($field_info as $property_label => $property) {
+
+      $selected_cv_info = $property[$selected_cv];
+      $insert_cvalues[$property_label] = $selected_cv_info;
+
+    }
 
 
     $extension = explode('.', $file_path);
@@ -414,7 +438,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     $organism_id,
     $analysis_id,
     $insert_fields,
-  $insert_cvalues
+    $insert_cvalues
 
   ) {
 
@@ -488,7 +512,8 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
    * @param $biosample
    * @param $analysis_id
    * @param $insert_fields
-   * @param $insert_cvalues - the cvalues to associate with the biomaterialprop.  Use this in addition to the property text value.
+   * @param $insert_cvalues - the cvalues to associate with the
+   *   biomaterialprop.  Use this in addition to the property text value.
    */
 
   protected function add_xml_data(
@@ -586,9 +611,14 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
   }
 
   /**
+   * Adds the properties for a biomaterial in the XML loader.
+   *
    * @param $attributes
    * @param $biomaterial_id
+   * @param $insert_fields
+   * @param $insert_cvalues
    */
+
   protected function add_xml_biomaterial_properties(
     $attributes,
     $biomaterial_id,
@@ -623,12 +653,18 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       // Insert into database.  Only insert into db if an existing CVTerm wasn't chosen
       $cv_name = 'biomaterial_property';
       if (isset($insert_fields[$attr_name])) {
-        $specified_cv = $insert_fields[$attr_name];
+
+        $specified_prop_cv = $insert_fields[$attr_name]['cv_name'];
+        $specified_prop_db = $insert_fields[$attr_name]['db_name'];
+        $specified_prop_accession = $insert_fields[$attr_name]['cvt_accession'];
+        $specified_prop_cvterm = $insert_fields[$attr_name]['cvt_name'];
+
+
+        $cv_name = $specified_prop_cv;
+        $attr_name = $specified_prop_cvterm;//we rename the attribute here, in case we chose a cvterm whose name is different from the attribute in the XML.
 
       }
-      if ($specified_cv) {
-        $cv_name = $specified_cv;
-      }
+
       else { //if a cv wasnt specified, or if this term wasnt set in the fields array, need to insert into the biomaterial_property CV
         if (!tripal_insert_cvterm([
           'name' => (string) $attr_name,
@@ -642,32 +678,28 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         }
       }
 
-      //TODO: test for cvalue
+      $cvalue_id = NULL;
 
-      $cvalue_id = null;
 
-      if (isset($insert_cvalues[$value])){
+      if (isset($insert_cvalues[$value])) {
         $specified_cvalue_cv_id = $insert_cvalues[$value];
-        //TODO look up this term in this CV
-
-        $specified_cvalue_cvterm = chado_cvterm
-
+        $cvalue_term = tripal_get_cvterm(['cvterm_id' => $specified_cvalue_cv_id]);
+        if (!$cvalue_term) {
+          print "ERROR: Invalid target CVterm provided for " . $value;
+          exit;
+        }
       }
-
-
-      //TODO: WE ALLOWED THE CVTERM FOR THE PROPERTY TO NO LONGER MATCH THE PROPERTY NAME (IE CASES WHERE THE HUMAN READABLE NAME WAS BETTER ETC).  HOW DO WE RECONCILE THIS?
 
       // Insert the property into the biomaterialprop table.
       $property = [
         'type_name' => $attr_name,
         'cv_name' => $cv_name,
         'value' => $value,
-        'cvalue_id' => $cvalue_id
+        'cvalue_id' => $cvalue_id,
       ];
       chado_insert_property($record, $property, $options);
     }
   }
-
 
 
   /**

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -142,14 +142,14 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       $link = variable_get('website_base_url') . "admin/tripal/loaders/chado_cv/cvterm/add.";
       $description = t('This section will allow you to check the CVterms associated with your biomaterial.  Ideally, each property should get the term for type and value from a Controlled Vocabulary (CV).  Alternatively you can create ad hoc terms in the biomaterialprop CV.  If the CVterm does not exist in a suitable CV, you can insert terms <a href = "' . $link . '"> using the Tripal CVterm loader.</a>');
 
-      $attributes_list = [];
+      $terms_to_check = null;
       if ($file_type == 'xml') {
-        $attributes_list = test_biosample_cvterms_xml($file_path, $organism_id, $analysis_id);
+        $terms_to_check = test_biosample_cvterms_xml($file_path, $organism_id, $analysis_id);
       }
       else {
-        $attributes_list = test_biosample_cvterms_flat($file_path);
+        $terms_to_check = test_biosample_cvterms_flat($file_path);
       }
-      $fields = $attributes_list;
+      $fields = $terms_to_check["attributes"];
     }
 
     $form['cvterm_configuration'] = [
@@ -161,6 +161,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       '#tree' => TRUE,
     ];
 
+    dpm($fields);
     foreach ($fields as $field) {
       $cv_array = [];
       //Get terms
@@ -217,6 +218,19 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         ];
       }
     }
+
+
+    $description = t('This section will allow you to check the CVterms associated with your biomaterial property <b>values</b>.  FOr example, if your property was "color", the property value might be "red".</a>');
+
+
+    $form['cvalue_configuration'] = [
+      '#type' => 'fieldset',
+      '#title' => t('CVterm Value Configuration'),
+      '#description' => $description,
+      '#prefix' => '<div id="cvterm_configuration_div">',
+      '#suffix' => '</div>',
+      '#tree' => TRUE,
+    ];
 
     return $form;
   }
@@ -831,17 +845,18 @@ function test_biosample_cvterms_xml(
       $biomaterial_names[] = $xml->BioSample[$i]->Ids->Id[1];
     }
 
-    $attribute_list = [];
+    $output = [];
 
     // Test all biomaterials
     for ($i = 0; $i < $num_biosamples; $i++) {
-      $attribute_list = test_xml_data($organism_id, $xml->BioSample[$i], $analysis_id, $attribute_list);
+      $output = test_xml_data($organism_id, $xml->BioSample[$i], $analysis_id, $output);
     }
   } catch (Exception $e) {
     print "\n";
     watchdog_exception('T_expression_load', $e);
   }
-  return $attribute_list;
+  return $output;
+
 }
 
 /**
@@ -855,18 +870,42 @@ function test_xml_data(
   $attribute_list
 ) {
 
-  // dpm($biosample);
-
 
   //get xml attributes
   $attributes = $biosample->Attributes->Attribute;
 
+  $attributes = $biosample->attributes();
+
+
+  foreach($attributes as $attribute_name => $attribute_value){
+    dpm($attribute_name);
+    dpm($attribute_value);
+
+  }
+
+  $attributes = $biosample->Attributes->Attribute;
+
   // Iterate through each property
   foreach ($attributes as $attr) {
+
     // Get the cvterm name
     $attr_name = (string) $attr->attributes()->attribute_name;
-    $attribute_list[$attr_name] = $attr_name;
+
+
+    //get all attribute names
+    $attr_names = $attr->attributes();
+
+    //get the cvterm value
+
+    $attr_value = (string) $attr;
+
+    $attribute_list["attributes"][$attr_name] = $attr_name;
+
+
+    $attribute_list["attribute_values"];
   }
+
+  //TODO TOGWOGGLE
   return ($attribute_list);
 }
 

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -142,7 +142,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       $link = variable_get('website_base_url') . "admin/tripal/loaders/chado_cv/cvterm/add.";
       $description = t('This section will allow you to check the CVterms associated with your biomaterial.  Ideally, each property should get the term for type and value from a Controlled Vocabulary (CV).  Alternatively you can create ad hoc terms in the biomaterialprop CV.  If the CVterm does not exist in a suitable CV, you can insert terms <a href = "' . $link . '"> using the Tripal CVterm loader.</a>');
 
-      $terms_to_check = null;
+      $terms_to_check = NULL;
       if ($file_type == 'xml') {
         $terms_to_check = test_biosample_cvterms_xml($file_path, $organism_id, $analysis_id);
       }
@@ -151,6 +151,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       }
       $fields = $terms_to_check["attributes"];
     }
+
 
     $form['cvterm_configuration'] = [
       '#type' => 'fieldset',
@@ -161,17 +162,25 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       '#tree' => TRUE,
     ];
 
-    dpm($fields);
+
     foreach ($fields as $field) {
+
       $cv_array = [];
+
+
+      $field_options = array_values($field);
+      $field_options = array_unique($field_options);
+
+
       //Get terms
       $sql = "SELECT CV.name AS cv_name, DB.name AS db_name, DBX.accession AS dbx_accession FROM {cvterm} AS CVT
               INNER JOIN {CV} AS CV ON CVT.cv_id = CV.cv_id
               INNER JOIN {dbxref} as DBX ON CVT.dbxref_id = DBX.dbxref_id
               INNER JOIN {db} as DB ON DBX.db_id = DB.db_id
-              WHERE CVT.name =:field";
+              WHERE CVT.name  IN (:field)";
 
-      $existing_field_terms = chado_query($sql, [":field" => $field])->fetchAll();
+      $existing_field_terms = chado_query($sql, [":field" => $field_options])->fetchAll();
+
       foreach ($existing_field_terms as $field_term) {
         $cv_name = $field_term->cv_name;
         $db_name = $field_term->db_name;
@@ -179,14 +188,22 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $cv_array[$cv_name]["cv"] = $cv_name;
         $cv_array[$cv_name]["db"] = $db_name;
         $cv_array[$cv_name]["accession"] = $accession;
-      }
-      //   $settings["CV_options"] = $cv_array;
 
-      $form['cvterm_configuration'][$field] = [
+      }
+
+      $field_label = reset($field);
+      $description = count($field_options) . " variations: ";
+
+      foreach ($field_options as $subfield) {
+        $description .= '"' . $subfield . '"' . "  ";
+      }
+
+      $form['cvterm_configuration'][$field_label] = [
         '#type' => 'fieldset',
-        '#title' => t($field),
+        '#title' => t($field_label),
         '#collapsible' => TRUE,
         '#collapsed' => FALSE,
+        '#description' => $description,
       ];
 
       $header = ["CV name", "DB name", "Accession"];
@@ -203,14 +220,14 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       //if no rows then the term isn't in DB.
 
       if (!$rows) {
-        $markup = "<p>There is no cvterm in the Chado database matching the property <b>$field</b>.  You can insert a term and try again, or submit and use a generic cv.</p>";
-        $form['cvterm_configuration'][$field]['cv_table'] = [
-          '#markup' => $markup
+        $markup = "<p>There is no cvterm in the Chado database matching the property <b>$field_label</b>.  You can insert a term and try again, or submit and use a generic cv.</p>";
+        $form['cvterm_configuration'][$field_label]['cv_table'] = [
+          '#markup' => $markup,
         ];
       }
       else {
 
-        $form['cvterm_configuration'][$field]['cv_table'] = [
+        $form['cvterm_configuration'][$field_label]['cv_table'] = [
           '#type' => 'tableselect',
           '#header' => $header,
           '#options' => $rows,
@@ -263,9 +280,9 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $insert_fields[$field] = $chosen_cv;
       }
     }
-      else {
-        tripal_set_message("Warning: properties not configured.  Using generic cvterms for all properties.", TRIPAL_WARNING);
-      }
+    else {
+      tripal_set_message("Warning: properties not configured.  Using generic cvterms for all properties.", TRIPAL_WARNING);
+    }
 
     $extension = explode('.', $file_path);
     $extension = $extension[count($extension) - 1];
@@ -414,7 +431,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     ]);
     $dbxref_biosample_id = $dbxref_biosample->dbxref_id;
 
-    $dbxref_id = null;
+    $dbxref_id = NULL;
     //note:  this dbxref (ncbi biosample) previously was insert into the biomaterial table.  This is incorrect: t his column is only for INTERNAL accessions.
 
     // If sra_accession is present, create entry in the dbxref table.
@@ -444,10 +461,10 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       ]);
     }
     //Also add the NCBI BioSample DBXREF previously inserted into the biomaterial table
-    if ($sample_accession){
+    if ($sample_accession) {
       tripal_associate_dbxref('biomaterial', $biomaterial_id, [
-        'accession'=> $sample_accession,
-        'db_name' => 'NCBI BioSample'
+        'accession' => $sample_accession,
+        'db_name' => 'NCBI BioSample',
       ]);
 
     }
@@ -679,9 +696,9 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
             $db_id = tripal_biomaterial_create_ncbi_db('sra', 'NCBI SRA', '');
           }
           elseif ($name == 'biosample_accession') {
-              // In case there is no biosample database
-              $db_id = tripal_biomaterial_create_ncbi_db('biosample', 'NCBI BioSample', '');
-            }
+            // In case there is no biosample database
+            $db_id = tripal_biomaterial_create_ncbi_db('biosample', 'NCBI BioSample', '');
+          }
           else {
             if ($name == 'bioproject_accession') {
               $db_id = tripal_biomaterial_create_ncbi_db('bioproject', 'NCBI BioProject', '');
@@ -786,7 +803,6 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
   }
 
 
-
   //end of class
 }
 
@@ -870,42 +886,53 @@ function test_xml_data(
   $attribute_list
 ) {
 
-
   //get xml attributes
+  //dont get ocnfused here-> we actually look for a node called "attributes" with child node "attribute"
   $attributes = $biosample->Attributes->Attribute;
+  foreach ($attributes as $key => $attribute_object) {
 
-  $attributes = $biosample->attributes();
+    $attribute_name_index = (string) $attribute_object->attributes()->attribute_name;
 
+    $attributes = $attribute_object->attributes(); // the list of attribute names, ie "name = tissue", "display_name = Tissue"
+    $property_value = $attribute_object->__toString();// the string value ie "leaf"
+    $this_attribute = [];
 
-  foreach($attributes as $attribute_name => $attribute_value){
-    dpm($attribute_name);
-    dpm($attribute_value);
+    foreach ($attributes as $property_sub_name => $property_sub_value) {
 
+      $value_string = (string) $property_sub_value;
+
+      //the attribute has multiple names: machine readable, human readable.  let's pass all of them to our tool so that any and all matches are found.
+
+      $this_attribute[$property_sub_name] = $value_string;
+    }
+
+    $attribute_list["attributes"][$attribute_name_index] = $this_attribute;
+    $attribute_list["values"] = $property_value;
   }
-
-  $attributes = $biosample->Attributes->Attribute;
-
-  // Iterate through each property
-  foreach ($attributes as $attr) {
-
-    // Get the cvterm name
-    $attr_name = (string) $attr->attributes()->attribute_name;
-
-
-    //get all attribute names
-    $attr_names = $attr->attributes();
-
-    //get the cvterm value
-
-    $attr_value = (string) $attr;
-
-    $attribute_list["attributes"][$attr_name] = $attr_name;
-
-
-    $attribute_list["attribute_values"];
-  }
-
-  //TODO TOGWOGGLE
+  //
+  //  $attributes = $biosample->Attributes->Attribute;
+  //
+  //  // Iterate through each property
+  //  foreach ($attributes as $attr) {
+  //
+  //    // Get the cvterm name
+  //    $attr_name = (string) $attr->attributes()->attribute_name;
+  //
+  //
+  //    //get all attribute names
+  //    $attr_names = $attr->attributes();
+  //
+  //    //get the cvterm value
+  //
+  //    $attr_value = (string) $attr;
+  //
+  //    $attribute_list["attributes"][$attr_name] = $attr_name;
+  //
+  //
+  //    $attribute_list["attribute_values"];
+  //  }
+  //
+  //  //TODO TOGWOGGLE
   return ($attribute_list);
 }
 

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -150,6 +150,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $terms_to_check = test_biosample_cvterms_flat($file_path);
       }
       $fields = $terms_to_check["attributes"];
+      $property_values = $terms_to_check["values"];
     }
 
 
@@ -173,7 +174,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
 
       //Get terms
-      $sql = "SELECT CV.name AS cv_name, DB.name AS db_name, DBX.accession AS dbx_accession FROM {cvterm} AS CVT
+      $sql = "SELECT CV.name AS cv_name, DB.name AS db_name, DBX.accession AS dbx_accession, CVT.name AS cvt_name, CVT.definition AS cvt_def FROM {cvterm} AS CVT
               INNER JOIN {CV} AS CV ON CVT.cv_id = CV.cv_id
               INNER JOIN {dbxref} as DBX ON CVT.dbxref_id = DBX.dbxref_id
               INNER JOIN {db} as DB ON DBX.db_id = DB.db_id
@@ -185,14 +186,19 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         $cv_name = $field_term->cv_name;
         $db_name = $field_term->db_name;
         $accession = $field_term->dbx_accession;
+        $cvt_name = $field_term->cvt_name;
+        $cvt_def = $field_term->cvt_def;
+
         $cv_array[$cv_name]["cv"] = $cv_name;
         $cv_array[$cv_name]["db"] = $db_name;
         $cv_array[$cv_name]["accession"] = $accession;
+        $cv_array[$cv_name]["cvt_name"] = $cvt_name;
+        $cv_array[$cv_name]["cvt_name"] = $cvt_def;
 
       }
 
       $field_label = reset($field);
-      $description = count($field_options) . " variations: ";
+      $description = count($field_options) . " variations queried: ";
 
       foreach ($field_options as $subfield) {
         $description .= '"' . $subfield . '"' . "  ";
@@ -206,14 +212,16 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
         '#description' => $description,
       ];
 
-      $header = ["CV name", "DB name", "Accession"];
+      $header = ["CVterm name",  "CV name", "DB name", "Accession", "CVterm definition"];
 
       $rows = [];
       foreach ($cv_array as $cv_name => $field_term) {
         $db_name = $field_term["db"];
         $accession = $field_term["accession"];
+        $cvt_name = $cv_array[$cv_name]["cvt_name"] ;
+        $cvt_def = $cv_array[$cv_name]["cvt_def"] ;
 
-        $row = [$cv_name, $db_name, $accession];
+        $row = [$cvt_name, $cv_name, $db_name, $accession, $cvt_def];
         $rows[$cv_name] = $row;
       }
 
@@ -248,6 +256,14 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       '#suffix' => '</div>',
       '#tree' => TRUE,
     ];
+
+
+
+    foreach ($property_values as $property_value){
+
+      dpm($property_value);
+
+    }
 
     return $form;
   }
@@ -907,32 +923,9 @@ function test_xml_data(
     }
 
     $attribute_list["attributes"][$attribute_name_index] = $this_attribute;
-    $attribute_list["values"] = $property_value;
+    $attribute_list["values"][] = $property_value;
   }
-  //
-  //  $attributes = $biosample->Attributes->Attribute;
-  //
-  //  // Iterate through each property
-  //  foreach ($attributes as $attr) {
-  //
-  //    // Get the cvterm name
-  //    $attr_name = (string) $attr->attributes()->attribute_name;
-  //
-  //
-  //    //get all attribute names
-  //    $attr_names = $attr->attributes();
-  //
-  //    //get the cvterm value
-  //
-  //    $attr_value = (string) $attr;
-  //
-  //    $attribute_list["attributes"][$attr_name] = $attr_name;
-  //
-  //
-  //    $attribute_list["attribute_values"];
-  //  }
-  //
-  //  //TODO TOGWOGGLE
+
   return ($attribute_list);
 }
 

--- a/tripal_biomaterial/tripal_biomaterial.install
+++ b/tripal_biomaterial/tripal_biomaterial.install
@@ -46,7 +46,17 @@ function tripal_biomaterial_install() {
   $update = db_update('tripal_views')->fields([
     'base_table' => 1,
   ])->condition('table_name', 'biomaterial', '=')->execute();
+
+
+  //Add cvalue_id if not already present in biomateiralprop
+
+  chado_query("ALTER TABLE {biomaterialprop} ADD COLUMN cvalue_id bigint;
+ALTER TABLE {biomaterialprop} ADD CONSTRAINT biomaterialprop_cvalue_id_fkey FOREIGN KEY (cvalue_id) REFERENCES {cvterm} (cvterm_id) ON DELETE SET NULL;
+");
+
 }
+
+
 
 /**
  * Add controlled vocabulary terms used by the biomaterials module.
@@ -193,4 +203,21 @@ function tripal_biomaterial_update_7300(){
         }
       }
     }
+}
+
+/**
+ * Updates the biomaterialprop table to support cvterm target values
+ *
+ */
+
+function tripal_biomaterial_update_7301() {
+
+  if (!chado_column_exists('biomaterialprop', 'cvalue_id')) {
+
+    chado_query("ALTER TABLE {biomaterialprop} ADD COLUMN cvalue_id bigint;
+ALTER TABLE {biomaterialprop} ADD CONSTRAINT biomaterialprop_cvalue_id_fkey FOREIGN KEY (cvalue_id) REFERENCES {cvterm} (cvterm_id) ON DELETE SET NULL;
+");
+  }
+
+
 }


### PR DESCRIPTION
Implements #187  CVtargets **and** #197  multiple property names.


## CVtargets

* The form can sample the cvterm text values (for XML only)
* User selects cvterm that directly matches the text value
* After picking term, the cvalue_id gets passed into the loader
* chado_add_property does not currently support `cvalue`.  Core would need to be updated for this (best solution)

## Multiple property labels

NCBI XML previously would have multiple labels for a property eg human readable, machine readable.  So `sample_name` and `Sample Name` might both be in the XML, but our script only looked for the attribute with a specific name.  No more: we now load in all the attribute labels, and check for cvterms matching any of them.


## Missing

* flat file support for CVtarget
* Setting property with cvtarget/cvalue.  This isnt here because we use a core method to set the property.  We would either need to update the core method, or implement outside of core (which im hesitant to do because the code is such a mess)


>![screen shot 2018-02-20 at 12 38 17 pm](https://user-images.githubusercontent.com/7063154/36439470-0ad2fa60-163b-11e8-9586-8641ce4d0321.png)
>cvterm value loader in action