### PR TITLE
Fix JS error in tripal 2 module

### DIFF
--- a/js/heatmap.js
+++ b/js/heatmap.js
@@ -2,12 +2,12 @@
   Drupal.behaviors.tripal_analysis_expression = {
     attach: function(context, settings){
       $(document).ready(function(){
-        var config = settings.tripal_analysis_expression:
-        if(! config){ return };
-        var heatmap_data = eval(config.heatmap_data);
+        this.settings = settings.tripal_analysis_expression:
+        if(! this.settings){ return };
+        var heatmap_data = eval(this.settings.heatmap_data);
         //var layout       = eval(settings.tripal_analysis_expression.heatmap_layout);
-        var left_margin = config.left_margin;
-        var bottom_margin = config.bottom_margin;
+        var left_margin = this.settings.left_margin;
+        var bottom_margin = this.settings.bottom_margin;
         var layout = {
                 title: 'Expression Heatmap',
                 /*

--- a/js/heatmap.js
+++ b/js/heatmap.js
@@ -2,8 +2,10 @@
   Drupal.behaviors.tripal_analysis_expression = {
     attach: function(context, settings){
       $(document).ready(function(){
-        this.settings = settings.tripal_analysis_expression:
-        if(! this.settings){ return };
+        this.settings = settings.tripal_analysis_expression;
+        if(!this.settings){
+            return;
+        }
         var heatmap_data = eval(this.settings.heatmap_data);
         //var layout       = eval(settings.tripal_analysis_expression.heatmap_layout);
         var left_margin = this.settings.left_margin;

--- a/js/heatmap.js
+++ b/js/heatmap.js
@@ -2,10 +2,12 @@
   Drupal.behaviors.tripal_analysis_expression = {
     attach: function(context, settings){
       $(document).ready(function(){
-        var heatmap_data = eval(settings.tripal_analysis_expression.heatmap_data); 
+        var config = settings.tripal_analysis_expression:
+        if(! config){ return };
+        var heatmap_data = eval(config.heatmap_data);
         //var layout       = eval(settings.tripal_analysis_expression.heatmap_layout);
-        var left_margin = settings.tripal_analysis_expression.left_margin;
-        var bottom_margin = settings.tripal_analysis_expression.bottom_margin;
+        var left_margin = config.left_margin;
+        var bottom_margin = config.bottom_margin;
         var layout = {
                 title: 'Expression Heatmap',
                 /*
@@ -16,7 +18,7 @@
                 margin: {
                   b: bottom_margin,
                   l: left_margin
-                }     
+                }
             }
         Plotly.newPlot('vis_expression', heatmap_data, layout);
       })

--- a/theme/js/heatmap.js
+++ b/theme/js/heatmap.js
@@ -2,10 +2,14 @@
   Drupal.behaviors.tripal_analysis_expression = {
     attach: function(context, settings){
       $(document).ready(function(){
-        var heatmap_data = eval(settings.tripal_analysis_expression.heatmap_data); 
+        this.settings = settings.tripal_analysis_expression;
+        if(!this.settings){
+            return;
+        }
+        var heatmap_data = eval(this.settings.heatmap_data);
         //var layout       = eval(settings.tripal_analysis_expression.heatmap_layout);
-        var left_margin = settings.tripal_analysis_expression.left_margin;
-        var bottom_margin = settings.tripal_analysis_expression.bottom_margin;
+        var left_margin = this.settings.left_margin;
+        var bottom_margin = this.settings.bottom_margin;
         var layout = {
                 title: 'Expression Heatmap',
                 /*
@@ -16,7 +20,7 @@
                 margin: {
                   b: bottom_margin,
                   l: left_margin
-                }     
+                }
             }
         Plotly.newPlot('vis_expression', heatmap_data, layout);
       })


### PR DESCRIPTION
Hello,

When loading any page without expression data, this call fails (heatmap.js) :
`eval(settings.tripal_analysis_expression.heatmap_data);`

Since it is loaded in every page, it breaks the javascript in any page where settings.tripal_analysis_expression is not set.
This was fixed later for the tripal 3 version, so I backported the fix (testing the value before evaluating).

I am aware the tripal2 version is not supported anymore, but it does break the interface.