### PR TITLE
[Tripal2] Fix 'No biomaterial libraries express this feature' issue

### DIFF
--- a/theme/templates/tripal_feature_expression.tpl.php
+++ b/theme/templates/tripal_feature_expression.tpl.php
@@ -5,7 +5,7 @@ $feature = $variables['node']->feature;
 
 if (!$variables['has_exp'] and $variables['json_exp']) { ?>
 
-No biomaterial libraries express this feature.
+All biomaterials associated with this feature have an expression value of 0.
 
 <?php }
 

--- a/theme/tripal_analysis_expression.theme.inc
+++ b/theme/tripal_analysis_expression.theme.inc
@@ -227,7 +227,7 @@ function tripal_analysis_expression_preprocess_tripal_feature_expression(&$varia
       $first_sig = 0;
     }
 
-    if ($exp->signal != $last_signal and $exp->signal != 0) {
+    if ($exp->signal != 0) {
       $has_exp = TRUE;
     }
     $last_signal = $exp->signal;
@@ -318,24 +318,3 @@ function tripal_analysis_expression_preprocess_tripal_organism_biomaterial(&$var
     $variables['biomaterial_ids'] = [];
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Fix #224 

I removed the check 'previous_value!=current value', which stopped the expression values from being shown when all biomaterials had the same expression value for the feature.

I did not remove the check 'value != 0', because we use the 'max value' to define the graph. If it's set to 0, the graph bugs out (division by 0). 

I feel like a simple modification of the "No biomaterial libraries express this feature" should be enough in that case. It should be clearer that 'There are biomaterials linked to this feature', but 'All expressions values are set to 0' 

No sure if what I wrote show this clearly though.

There was no apparent error after these fixes, so the 'previous_value!=current value' check might have been obsolete.

