### PR TITLE
Fixed permissions for downloading expression content

### DIFF
--- a/tripal_analysis_expression/theme/templates/tripal_analysis_expression.feature.tpl.php
+++ b/tripal_analysis_expression/theme/templates/tripal_analysis_expression.feature.tpl.php
@@ -45,7 +45,7 @@
 
 <figure id="analysis-expression-figure"></figure>
 
-<?php if (user_access('download content')) : ?>
+<?php if (user_access('download expression content')) : ?>
   <a href="/tripal/analysis-expression/download?feature_ids=<?php print $variables['feature_id'] ?>&analysis_id=<?php print $variables['default_analysis_id']; ?>"
      id="expressionDownloadLink">
       Download expression dataset for this feature

--- a/tripal_analysis_expression/theme/templates/tripal_analysis_expression.feature.tpl.php
+++ b/tripal_analysis_expression/theme/templates/tripal_analysis_expression.feature.tpl.php
@@ -45,7 +45,9 @@
 
 <figure id="analysis-expression-figure"></figure>
 
-<a href="/tripal/analysis-expression/download?feature_ids=<?php print $variables['feature_id'] ?>&analysis_id=<?php print $variables['default_analysis_id']; ?>"
-   id="expressionDownloadLink">
-    Download expression dataset for this feature
-</a>
+<?php if (user_access('download content')) : ?>
+  <a href="/tripal/analysis-expression/download?feature_ids=<?php print $variables['feature_id'] ?>&analysis_id=<?php print $variables['default_analysis_id']; ?>"
+     id="expressionDownloadLink">
+      Download expression dataset for this feature
+  </a>
+<?php endif; ?>

--- a/tripal_analysis_expression/tripal_analysis_expression.module
+++ b/tripal_analysis_expression/tripal_analysis_expression.module
@@ -25,6 +25,10 @@ function tripal_analysis_expression_permission() {
       'title' => t('Edit tripal analysis expression settings'),
       'description' => t('Edit tripal analysis expression settings'),
     ],
+    'download content' => [
+      'title' => t('Download expression content'),
+      'description' => t('Allow users to download expression content')
+    ]
   ];
 }
 

--- a/tripal_analysis_expression/tripal_analysis_expression.module
+++ b/tripal_analysis_expression/tripal_analysis_expression.module
@@ -25,7 +25,7 @@ function tripal_analysis_expression_permission() {
       'title' => t('Edit tripal analysis expression settings'),
       'description' => t('Edit tripal analysis expression settings'),
     ],
-    'download content' => [
+    'download expression content' => [
       'title' => t('Download expression content'),
       'description' => t('Allow users to download expression content')
     ]


### PR DESCRIPTION
added the option to change permissions for users downloading expression content

link for download now only appears if the user is authorized to download expression content

