### PR TITLE
Added support for Tripal 3's legacy PHP template and fixed display issues for data loaded using the Tripal 2 version of the Tripal Analysis Expression module.

### DIFF
--- a/tripal_analysis_expression/includes/HeatMapGenerator.inc
+++ b/tripal_analysis_expression/includes/HeatMapGenerator.inc
@@ -116,7 +116,7 @@ class HeatMapGenerator{
             INNER JOIN {biomaterial} B ON B.biomaterial_id = AB.biomaterial_id
             INNER JOIN {analysis} AN ON AN.analysis_id = Q.analysis_id
             LEFT JOIN {contact} C ON B.biosourceprovider_id = C.contact_id
-            WHERE F.uniquename IN (:uniquenames)";
+            WHERE F.name IN (:uniquenames)";
 
     $expressionData = chado_query($sql, [
       ':uniquenames' => $this->featureNames,

--- a/tripal_analysis_expression/includes/feature_heatmap_form.inc
+++ b/tripal_analysis_expression/includes/feature_heatmap_form.inc
@@ -307,7 +307,8 @@ function tripal_analysis_expression_search_features($field, $value, $support_org
   $organism = isset($_GET['organism']) ? $_GET['organism'] : NULL;
 
   $query = db_select('chado.expression_feature', 'EF');
-  $query->addField('EF', 'feature_uniquename', 'uniquename');
+  $query->join('chado.feature', 'F', 'EF.feature_id = F.feature_id');
+  $query->addField('F', 'name', 'name');
   $query->addField('EF', 'organism_common_name', 'common_name');
   $query->addField('EF', 'accession', 'accession');
   $query->orderBy($field, 'ASC');
@@ -318,7 +319,7 @@ function tripal_analysis_expression_search_features($field, $value, $support_org
   }
 
   if (!empty($organism) && $support_organism) {
-    $query->condition('organism_id', $organism);
+    $query->condition('EF.organism_id', $organism);
   }
 
   $results = $query->execute();
@@ -343,8 +344,8 @@ function feature_heatmap_get_organisms() {
     return drupal_map_assoc(tripal_elasticsearch_get_gene_search_organisms());
   }
 
-  $sql = 'SELECT genus, species, common_name, organism_id
-            FROM {organism} 
+  $sql = 'SELECT genus, species, common_name, O.organism_id
+            FROM {organism} O INNER JOIN {expression_feature} EF ON O.organism_id = EF.organism_id
             ORDER BY genus ASC, species ASC';
 
   $organism_list = chado_query($sql)->fetchAll();

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -132,6 +132,7 @@
       selectorColor.append('option')
           .attr('value', 'Expression value')
           .text('Expression value');
+      this.currentColor = 'Expression value'; 
 
       this.heatMap.map(function (biomaterial) {
         Object.keys(biomaterial.properties).map(function (property_key) {
@@ -341,7 +342,7 @@ var averageStepSize = calculatedWidth/totalSamples
           .attr('x', 0)
           .attr('y', 0)
           .html(function (d) {
-              if (d.key === "spacing_group_for_domain"){
+              if (d.key === "spacing_group_for_domain" || d.key === 'Not set'){
                   return //skip plotting the spacing group
               }
 

--- a/tripal_analysis_expression/theme/js/heatmap-search.js
+++ b/tripal_analysis_expression/theme/js/heatmap-search.js
@@ -103,7 +103,7 @@
     },
 
     renderRow: function (row) {
-      var name = row.uniquename;
+      var name = row.name;
 
       var disabled = this.getFeatures().indexOf(name) > -1 ? ' disabled' : '';
 

--- a/tripal_analysis_expression/theme/templates/tripal_feature_expression.tpl.php
+++ b/tripal_analysis_expression/theme/templates/tripal_feature_expression.tpl.php
@@ -1,6 +1,11 @@
+<?php $default_analysis_id = 0;?>
+<?php $node = $variables['node']; $feature_id = $node->chado_record->feature_id;?>
+<?php $has_expression = db_query('SELECT feature_id FROM chado.expression_feature WHERE feature_id = :feature_id', array(':feature_id' => $feature_id))->fetchField(); if(!$has_expression) {return;}?>
 <p><strong>Available Analyses</strong></p>
 <ul>
+
     <?php foreach ($variables['analyses'] as $analysis) : ?>
+            <?php $default_analysis_id = $analysis->analysis_id; ?>
     <li><?php print l($analysis->name, 'bio_data/'.chado_get_record_entity_by_table('analysis', $analysis->analysis_id)) ?></li>
     <?php endforeach; ?>
 </ul>
@@ -45,7 +50,7 @@
 
 <figure id="analysis-expression-figure"></figure>
 
-<a href="/tripal/analysis-expression/download?feature_ids=<?php print $variables['feature_id'] ?>&analysis_id=<?php print $variables['default_analysis_id']; ?>"
+<a href="/tripal/analysis-expression/download?feature_ids=<?php print $feature_id ?>&analysis_id=<?php print $default_analysis_id; ?>"
    id="expressionDownloadLink">
     Download expression dataset for this feature
 </a>

--- a/tripal_analysis_expression/theme/templates/tripal_feature_expression.tpl.php
+++ b/tripal_analysis_expression/theme/templates/tripal_feature_expression.tpl.php
@@ -1,0 +1,51 @@
+<p><strong>Available Analyses</strong></p>
+<ul>
+    <?php foreach ($variables['analyses'] as $analysis) : ?>
+    <li><?php print l($analysis->name, 'bio_data/'.chado_get_record_entity_by_table('analysis', $analysis->analysis_id)) ?></li>
+    <?php endforeach; ?>
+</ul>
+
+<p><strong>Select an Expression Analysis</strong></p>
+
+<select id="analyses-dropdown">
+  <?php foreach ($variables['analyses'] as $analysis) : ?>
+      <option value="<?php print $analysis->analysis_id; ?>">
+        <?php print $analysis->name; ?>
+      </option>
+  <?php endforeach; ?>
+</select>
+
+<p id="propertySortDiv">
+    <strong>Select a property to group and sort biological samples</strong>
+</p>
+
+<p id="propertyColorDiv">
+    <strong>Select a property to color biological samples</strong>
+</p>
+
+<p>
+    Hover the mouse over a column in the graph to view more information about
+    that biological sample.
+    You can click and drag to rearrange groups along the x-axis. You can also
+    click and drag to move the legend.
+</p>
+
+<p>
+    <a href="javascript:;" id="show-non-zero-only">Only Non-Zero Values</a> |
+    <a href="javascript:;" id="reset-expression-plot">Reset</a>
+</p>
+
+<script type="text/javascript">
+  Drupal.behaviors.tripal_analysis_expression = {
+    attach: function (context, settings) {
+
+    }
+  };
+</script>
+
+<figure id="analysis-expression-figure"></figure>
+
+<a href="/tripal/analysis-expression/download?feature_ids=<?php print $variables['feature_id'] ?>&analysis_id=<?php print $variables['default_analysis_id']; ?>"
+   id="expressionDownloadLink">
+    Download expression dataset for this feature
+</a>

--- a/tripal_analysis_expression/theme/tripal_analysis_expression.theme.inc
+++ b/tripal_analysis_expression/theme/tripal_analysis_expression.theme.inc
@@ -1,2 +1,25 @@
 <?php
 
+function tripal_analysis_expression_preprocess_tripal_feature_expression(&$variables) {
+  $feature = $variables['node']->feature;
+  $sql = "SELECT DISTINCT(AN.analysis_id), AN.name
+              FROM {elementresult} ER
+              INNER JOIN {element} E ON E.element_id = ER.element_id
+              INNER JOIN {feature} F ON F.feature_id = E.feature_id
+              INNER JOIN {quantification} Q ON Q.quantification_id = ER.quantification_id
+              INNER JOIN {acquisition} AQ ON AQ.acquisition_id = Q.acquisition_id
+              INNER JOIN {assay} A ON A.assay_id = AQ.assay_id
+              INNER JOIN {assay_biomaterial} AB ON AB.assay_id = A.assay_id
+              INNER JOIN {biomaterial} B ON B.biomaterial_id = AB.biomaterial_id
+              INNER JOIN {analysis} AN ON AN.analysis_id = Q.analysis_id
+              WHERE F.feature_id = :feature_id";
+  $analyses = chado_query($sql, [":feature_id" => $feature->feature_id]);
+  if ($analyses) {
+    $analyses = $analyses->fetchAll();
+    foreach ($analyses as $key => $analysis) {
+      $analyses[$key]->url = 'bio_data/' . chado_get_record_entity_by_table('analysis',
+          $analysis->analysis_id);
+    }
+    $variables['analyses'] = $analyses;
+  }
+}

--- a/tripal_analysis_expression/tripal_analysis_expression.module
+++ b/tripal_analysis_expression/tripal_analysis_expression.module
@@ -102,7 +102,7 @@ function tripal_analysis_expression_menu() {
 
   $items['tripal/analysis-expression/download'] = [
     'title' => '',
-    'access arguments' => ['download content'],
+    'access arguments' => ['access content'],
     'page callback' => 'analysis_expression_data_downloader::callback',
     'type' => MENU_CALLBACK,
   ];
@@ -151,6 +151,13 @@ function tripal_analysis_expression_theme($existing, $type, $theme, $path) {
       'template' => 'tripal_analysis_expression.feature',
       'path' => "$path/theme/templates",
     ],
+    
+    // tripal_feature theme
+    'tripal_feature_expression' => array (
+      'template' => 'tripal_feature_expression',
+      'variables' => array ('node' => NULL),
+      'path' => "$path/theme/templates"
+    ),
   ];
   return $items;
 }
@@ -283,5 +290,25 @@ function tripal_analysis_expression_heatmap_block(&$block) {
                                </p>');
       }
     }
+  }
+}
+
+/*******************************************************************************
+ * tripal_analysis_expression_nodeapi()
+ * HOOK: Implementation of hook_nodeapi()
+ * Display blast results for allowed node types
+ */
+function tripal_analysis_expression_node_view($node, $view_mode, $langcode) {
+  
+  switch ($node->type) {
+    case 'chado_feature':
+      if ($view_mode == 'full') {
+        $node->content['tripal_feature_expression'] = array(
+          '#markup' => theme('tripal_feature_expression', array('node' => $node)),
+          '#tripal_toc_id'    => 'expression',
+          '#tripal_toc_title' => 'Expression',
+        );
+      }
+      break;
   }
 }


### PR DESCRIPTION
The current module does not support legacy template in Tripal 3. This PR added support for legacy PHP templates if they're used in Tripal 3, along with a couple display issues we found for the data loaded using the Tripal 2 version of the Tripal Analysis Expression module.

Example pages:
1. Heatmap
https://www.vaccinium.org/node/854703

2. Feature expression:
https://www.vaccinium.org/bio_data/708347?pane=expression
