### PR TITLE
Update tripal_biomaterial_loader_v3.inc

### DIFF
--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -17,8 +17,8 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
   public static $file_types = ['xml', 'tsv', 'csv'];
 
-  public static $upload_description = "Please upload an NCBI BioSample file.  This can be in XML with an .xml extension, or flat file format with a .tsv or .csv extension.<br><br> If loading a CSV/TSV flat file, the first line must be the column name.  The only field that is required to create a biosample is the name (column: sample_name). It is recommended that a description (column: description), biomaterial provider (column: biomaterial_provider), accession (column: biomaterial_accession), treatment (column: treatment), and tissue (column: tissue) also be provided. A biomaterialprop cvterm type will be created for column 
-    titles not associated with a cvterm below.  <br>This loader will create dbxref records for the following 
+  public static $upload_description = "Please upload an NCBI BioSample file.  This can be in XML with an .xml extension, or flat file format with a .tsv or .csv extension.<br><br> If loading a CSV/TSV flat file, the first line must be the column name.  The only field that is required to create a biosample is the name (column: sample_name). It is recommended that a description (column: description), biomaterial provider (column: biomaterial_provider), accession (column: biomaterial_accession), treatment (column: treatment), and tissue (column: tissue) also be provided. A biomaterialprop cvterm type will be created for column
+    titles not associated with a cvterm below.  <br>This loader will create dbxref records for the following
     column headers if present: biosample_accession, bioproject_accession, and sra_accession. Other accessions should
     be uploaded using a bulk loader template. ";
 
@@ -608,7 +608,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     fclose($fp);
 
     if ($num_biosamples == 0) {
-      $message = "Wrong file format at !path. File must contain a column named 'sample_name'.  
+      $message = "Wrong file format at !path. File must contain a column named 'sample_name'.
         Please try again with a file that contains at least one column named 'sample_name' in its header line, followed by lines of biosample data.";
       $this->logMessage($message, ['!path' => $file_path], TRIPAL_ERROR);
       return;
@@ -837,18 +837,18 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
     $file_path = NULL;
 
-    if (isset($values['file_local'])) {
+    if (!empty($values['file_local'])) {
       $file_path = trim($values['file_local']);
     }
-    if (isset($form_state['values']['file_upload'])) {
-      $fid = trim($values['file_upload'][0]);
+    if (!empty($values['file_upload'])) {
+      $fid = trim($values['file_upload']);
       if (!empty($fid)) {
         $file = file_load($fid);
         $file_path = base_path() . drupal_realpath($file->uri);
       }
     }
 
-    if (isset($values['file_upload_existing'])) {
+    if (!empty($values['file_upload_existing'])) {
       $fid = $values['file_upload_existing'];
       if (!empty($fid)) {
         $file = file_load($fid);
@@ -984,8 +984,9 @@ function test_biosample_cvterms_flat(
   $fileSize = filesize($file_path);
   if ($fileSize == 0) {
 
-    $this->logMessage("File at !file_path is empty. Try again with a new file.",
-      ['!file_path' => $file_path], TRIPAL_ERROR);
+   error_log("File at !file_path is empty. Try again with a new file. file_path: $file_path", 0);
+   #$this->logMessage("File at !file_path is empty. Try again with a new file.",
+   #   ['!file_path' => $file_path], TRIPAL_ERROR);
     return;
   }
   // Figure out CSV vs TSV.
@@ -1020,14 +1021,17 @@ function test_biosample_cvterms_flat(
 
   // Print error message and exit if there's no biosample, or that there's no "sample_name" column in flat file.
   if ($num_biosamples == 0) {
-    $this->logMessage("Wrong file format at !file_path. File must contain a column named 'sample_name'.",
-      ['!file_path' => $file_path], TRIPAL_ERROR);
+    error_log("Wrong file format at !file_path. File must contain a column named 'sample_name'. $file_path", 0);
+    #$this->logMessage("Wrong file format at !file_path. File must contain a column named 'sample_name'.",
+    #  ['!file_path' => $file_path], TRIPAL_ERROR);
     return;
   }
 
   // Get the file pointer.
   $fp = fopen($file_path, "r");
+  $nLineHeader = 0;
   while ($line = fgetcsv($fp, 0, $separator, $enclosure)) {
+    $nLineHeader++;
     foreach ($line as $field) {
       if (preg_match("/(sample_name)/", $field)) {
         break 2;
@@ -1043,6 +1047,7 @@ function test_biosample_cvterms_flat(
     return;
   }
 
+  $attribute_list["values"] = [];
   for ($i = 0; $i < count($headers); $i++) {
     $header = trim(str_replace("*", "", $headers[$i]));
     if (in_array($header, [
@@ -1056,13 +1061,20 @@ function test_biosample_cvterms_flat(
     ])) {
     }
     else {
-      $attribute_list[]["attributes"] = $header;
-
-      // TODO: this is where the flat file loader would support checking the cvalues as well.
-      $attribute_list[]["values"] = NULL;
-
+      $attribute_list["attributes"][$header] = $header;
     }
   }
+
+  // Fill the values into the attribute_list array from lines in the file. Starting from the next line after the header
+  $tmpNumLine = 0;
+  while ($line = fgetcsv($fp, 0, $separator, $enclosure)) {
+    $tmpNumLine++;
+    if($tmpNumLine > $nLineHeader){
+      $attribute_list["values"] = array_merge($attribute_list["values"], $line);
+    }
+  }
+  $attribute_list["values"] = array_valuesarray_unique($attribute_list["values"]);
+
   return ($attribute_list);
 }
 


### PR DESCRIPTION
Fixing error loading tsv and csv Biosamples

1. Change the validation isset into !empty:

The value set by default in $values['file_local'], $values['file_upload'] and $values['file_upload_existing'] is NULL, so the isset will consider the statement as TRUE.

2. Change the function to print the error log in the function test_biosample_cvterms_flat:

When the flat file was not found in the server or when there are not samples in the flat file, the system prints an error message in the log, however when it attempts to call the function logMessage it generates the following error:

Error: Using $this when not in object context in test_biosample_cvterms_flat() (line 1039 of /var/www/html/sites/all/modules/tripal_analysis_expression/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
To fix this bug I print the error message in the log by means of the function error_log instead of logMessage

3. Read the attributes and values of the flat file and set them into the attributes_list in a consistent format:

Firstly I declared a variable to determine the number of the row containing the header: $nLineHeader
The values in attribute list is initialized empty: $attribute_list["values"] = [];
Set only one value "attributes" in the attributes list, which contains the unique headers: $attribute_list["attributes"][$header] = $header;
Fill the unique values into the attribute_list array from lines in the flat file, starting from the next line after the header.