### PR TITLE
Mouse events on chart tooltips

### DIFF
--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -318,7 +318,7 @@
         .style('overflow', 'auto')
         .style('max-width', '100%')
         .on('scroll', function() {
-          console.log('scrolling')
+          $(document).trigger($.Event('figure.scroll'))
         })
 
       var svg = d3.select('figure')
@@ -574,6 +574,10 @@
           .duration(200)
           .style('opacity', 0)
           .style('display', 'none')
+      })
+
+      $(document).on('figure.scroll', function() {
+        console.log('scrolling')
       })
 
       this.buildLegend(color, calculatedWidth, margin, height)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -554,14 +554,15 @@
             .style('top', ((d3.event.pageY - (200)) + 'px'))
         })
         .on('mouseout', function () {
-          d3.select(this).style('opacity', 1)
-          $(divTooltip[0]).once('mouseout', function () {
-            divTooltip.transition()
-              .duration(500)
-              .style('opacity', 0)
-              .style('display', 'none')
-          })
         })
+
+      divTooltip.on('mouseout', function() {
+        console.log('out')
+        divTooltip.transition()
+          .duration(500)
+          .style('opacity', 0)
+          .style('display', 'none')
+      })
 
       $(document).on('click', function (e) {
         if ($(e.target).parents('#chart-tooltip').length || $(e.target).attr('id') === 'chart-tooltip') {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -517,39 +517,60 @@
 
 //Add the tool tip
 
-      var divTooltip = d3
-        .select('body')
-        .append('div')
-        .attr('class', 'toolTip')
+      // var divTooltip = d3
+      //   .select('body')
+      //   .append('div')
+      //   .attr('class', 'toolTip')
+      //   .attr('id', 'chart-tooltip')
+      //   .style('position', 'absolute')
+      //   .style('max-width', '250px')
+      //   .style('padding', '10px')
+      //   .style('font-size', '12px')
+      //   .style('font-family', 'Helvetica, Roboto, sans-serif')
+      //   .style('background', 'rgba(255, 255, 255, .9)')
+      //   .style('border', '1px solid rgba(0,0,0,.3)')
+      //   .style('border-radius', '5px')
+      //   .style('pointer-events', 'none')
+      //   .style('display', 'none')
+      //   .style('opacity', 0)
+      //   .style('transition', 'opacity .25s linear')
+      //   .style('z-index', 9999999999)
+
+      var divTooltip = $('<div />')
+        .addClass('toolTip')
         .attr('id', 'chart-tooltip')
-        .style('position', 'absolute')
-        .style('max-width', '250px')
-        .style('padding', '10px')
-        .style('font-size', '12px')
-        .style('font-family', 'Helvetica, Roboto, sans-serif')
-        .style('background', 'rgba(255, 255, 255, .9)')
-        .style('border', '1px solid rgba(0,0,0,.3)')
-        .style('border-radius', '5px')
-        .style('pointer-events', 'none')
-        .style('display', 'none')
-        .style('opacity', 0)
-        .style('transition', 'opacity .25s linear')
-        .style('z-index', 9999999999)
+        .css('position', 'absolute')
+        .css('max-width', '250px')
+        .css('padding', '10px')
+        .css('font-size', '12px')
+        .css('font-family', 'Helvetica, Roboto, sans-serif')
+        .css('background', 'rgba(255, 255, 255, .9)')
+        .css('border', '1px solid rgba(0,0,0,.3)')
+        .css('border-radius', '5px')
+        .css('pointer-events', 'none')
+        .css('display', 'none')
+        .css('opacity', 0)
+        .css('transition', 'opacity .25s linear')
+        .css('z-index', 9999999999)
+
+      $('body').append(divTooltip)
 
       bars.on('mouseover', function (d) {
         var propTable = _that.buildPropertyTooltipTable(d)
-        divTooltip.transition()
-          .duration(200)
-          .style('opacity', 1)
-          .style('display', 'block')
+        // divTooltip.transition()
+        //   .duration(200)
+        //   .style('opacity', 1)
+        //   .style('display', 'block')
 
         divTooltip.html(
-          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'">' + d.name + '</a><br/>' +
+          '<strong>Biosample:</strong> <a href="/bio_data/' + d.node + '">' + d.name + '</a><br/>' +
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)
           .style('left', ($(this).offset().left - 260) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
+
+        divTooltip.fadeIn()
 
         let pos = d3.event.pageY
         setTimeout(function () {
@@ -564,10 +585,12 @@
           return
         }
 
-        divTooltip.transition()
-          .duration(500)
-          .style('opacity', 0)
-          .style('display', 'none')
+        divTooltip.fadeOut()
+
+        // divTooltip.transition()
+        //   .duration(500)
+        //   .style('opacity', 0)
+        //   .style('display', 'none')
       })
 
       this.buildLegend(color, calculatedWidth, margin, height)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -554,10 +554,12 @@
           + propTable)
           .style('left', ($(this).offset().left - 260) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
-        divTooltip.transition()
-          .duration(200)
-          .style('opacity', 1)
-          .style('display', 'block')
+        setTimeout(function() {
+          divTooltip.transition()
+            .duration(200)
+            .style('opacity', 1)
+            .style('display', 'block')
+        }, 500)
       })
 
       $(document).on('click', function (e) {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -549,15 +549,21 @@
           .style('top', ((d3.event.pageY - (200)) + 'px'))
 
         let pos = d3.event.pageY
-        setTimeout(function() {
+        setTimeout(function () {
           var height = divTooltip[0].outerHeight / 2
-            divTooltip.style('top', ((pos - height) + 'px'))
+          divTooltip.style('top', ((pos - height) + 'px'))
         }, 200)
-        console.log(divTooltip[0])
       })
 
-      $(document).on('click', function (d) {
-        console.log(divTooltip)
+      $(document).on('click', function (e) {
+        if (e.target && e.target.contains(divTooltip[0])) {
+          return
+        }
+
+        if (e.target && e.target === divTooltip[0]) {
+          return
+        }
+
         divTooltip.transition()
           .duration(500)
           .style('opacity', 0)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -553,7 +553,7 @@
         .css('transition', 'opacity .25s linear')
         .css('z-index', 9999999999)
 
-      $('body').append(divTooltip)
+      $('body').prepend(divTooltip)
 
       bars.on('mouseover', function (d) {
         var propTable = _that.buildPropertyTooltipTable(d)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -523,8 +523,8 @@
         .on('mouseover', function (d, i) {
           d3.select(this).style('opacity', .5)
           initialTooltip
-            .style('left', ($(this).offset().left - 50) + 'px')
-            .style('top', ((d3.event.pageY - (50)) + 'px'))
+            .style('left', ($(this).offset().left - 100) + 'px')
+            .style('top', ((d3.event.pageY - (100)) + 'px'))
 
           initialTooltip.transition()
             .duration(200)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -559,7 +559,7 @@
       })
 
       $(document).on('click', function (e) {
-        console.log($(this))
+        console.log($(this), $(this).parents('#chart-tooltip'), $(this).attr('id') === 'chart-tooltip')
         if ($(this).parents('#chart-tooltip') || $(this).attr('id') === 'chart-tooltip') {
           return
         }

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -544,7 +544,7 @@
           .style('display', 'block')
 
         divTooltip.html(
-          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'">' + d.name + '</a><br/>' +
+          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'" onclick="alert(\'clicked\')">' + d.name + '</a><br/>' +
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -539,13 +539,6 @@
 
       bars
         .on('mouseover', function (d, i) {
-          d3.select(this).style('opacity', .5).style('pointer-events', 'visible')
-        })
-        .on('mouseout', function () {
-          d3.select(this).style('opacity', 1)
-        })
-        .on('click', function (d) {
-          console.log(d)
           var propTable = _that.buildPropertyTooltipTable(d)
           divTooltip.transition()
             .duration(200)
@@ -559,6 +552,15 @@
             + propTable)
             .style('left', ($(this).offset().left - 260) + 'px')
             .style('top', ((d3.event.pageY - (200)) + 'px'))
+        })
+        .on('mouseout', function () {
+          d3.select(this).style('opacity', 1)
+          $(divTooltip[0]).once('mouseout', function () {
+            divTooltip.transition()
+              .duration(500)
+              .style('opacity', 0)
+              .style('display', 'none')
+          })
         })
 
       $(document).on('click', function (e) {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -523,8 +523,8 @@
         .on('mouseover', function (d, i) {
           d3.select(this).style('opacity', .5)
           initialTooltip
-            .style('left', ($(this).offset().left - 20) + 'px')
-            .style('top', ((d3.event.pageY - (20)) + 'px'))
+            .style('left', ($(this).offset().left - 50) + 'px')
+            .style('top', ((d3.event.pageY - (50)) + 'px'))
 
           initialTooltip.transition()
             .duration(200)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -549,7 +549,7 @@
           .style('top', ((d3.event.pageY - (200)) + 'px'))
       })
 
-      document.on('mouseout', function (d) {
+      $(document).on('click', function (d) {
         console.log(divTooltip)
         divTooltip.transition()
           .duration(500)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -3,6 +3,7 @@
   Drupal.behaviors.expression = {
     attach: function (context, settings) {
       // Define variables
+      this.activeBar        = null
       this.heatMapRaw       = JSON.parse(settings.heatMapRaw)
       this.selectedAnalysis = settings.selectedAnalysis
       this.feature_id       = settings.feature_id
@@ -530,7 +531,6 @@
         .style('background', 'rgba(255, 255, 255, .9)')
         .style('border', '1px solid rgba(0,0,0,.3)')
         .style('border-radius', '5px')
-        // .style('pointer-events', 'none')
         .style('display', 'none')
         .style('opacity', 0)
         .style('transition', 'opacity .25s linear')
@@ -544,18 +544,12 @@
           .style('display', 'block')
 
         divTooltip.html(
-          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'">' + d.name + '</a><br/>' +
+          '<strong>Biosample:</strong> <a href="/bio_data/' + d.node + '">' + d.name + '</a><br/>' +
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)
           .style('left', ($(this).offset().left - 260) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
-
-        let pos = d3.event.pageY
-        setTimeout(function () {
-          var height = divTooltip[0].outerHeight / 2
-          divTooltip.style('top', ((pos - height) + 'px'))
-        }, 200)
       })
 
       $(document).on('click', function (e) {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -553,16 +553,6 @@
             .style('left', ($(this).offset().left - 260) + 'px')
             .style('top', ((d3.event.pageY - (200)) + 'px'))
         })
-        .on('mouseout', function () {
-        })
-
-      divTooltip.on('mouseout', function() {
-        console.log('out')
-        divTooltip.transition()
-          .duration(500)
-          .style('opacity', 0)
-          .style('display', 'none')
-      })
 
       $(document).on('click', function (e) {
         if ($(e.target).parents('#chart-tooltip').length || $(e.target).attr('id') === 'chart-tooltip') {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -393,74 +393,36 @@
 
 
       // propertyGroups.call(d3.behavior.drag()
-      //   .origin(function (d, i) {  // define the start drag as the middle of the group
-      //     // this should match the transformation used when assigning the
-      //     // group
-      //     return {x: _that.translationXOffset(d.position, x0)}
-      //   })
-      //   .on('dragstart', function (d, i) {
-      //     // track the position of the selected group in the dragging object
-      //     dragging[d.key] = _that.translationXOffset(d.position, x0)
-      //     var sel         = d3.select(this)
-      //     sel.moveToFront()
-      //   })
-      //   .on('drag', function (d, i) {// track current drag location
-      //     dragging[d.key] = d3.event.x
-      //
-      //     nested.sort(function (a, b) {
-      //       return position(a, a.position, x0) - position(b, b.position, x0)
-      //     })
-      //
-      //
-      //     ///rebuild the domain
-      //     //TODO:  This is very not - DRY, copied from initial domain set.
-      //     // should be factored out.
-      //
-      //     var rangeMapper   = {}
-      //     var lengthTracker = 0 //keep track of where we are on the scale
-      //
-      //     nested.map(function (d, i) {
-      //
-      //       var groupSize = d.values.length * averageStepSize
-      //       //   var location = lengthTracker + groupSize/2 //set the location
-      //       // to the middle of its group var location = lengthTracker +
-      //       // groupSize/2 //set the location to the middle of its group
-      //       var location = lengthTracker //set the location to the start of its
-      //       // group
-      //
-      //       rangeMapper[d.key]    = location
-      //       lengthTracker += groupSize
-      //       nested[i]['position'] = i
-      //     })
-      //
-      //
-      //     x0 = d3.scale.linear()
-      //       .rangeRound(nested.map(function (d) {
-      //         return rangeMapper[d.key]
-      //       }))
-      //
-      //     // Set the domains based on the nested data
-      //     x0.domain(nested.map(function (d, i) {
-      //       return i
-      //     }))
-      //
-      //     propertyGroups.attr('transform', function (d) {
-      //
-      //       return 'translate(' + position(d, d.position, x0) + ', 0)'
-      //     })
-      //   })
-      //   .on('dragend', function (d, i) {
-      //     delete dragging[d.key]
-      //     transition(d3.select(this)).attr('transform', function (d) {
-      //       return 'translate(' + _that.translationXOffset(d.position, x0) + ',0)'
-      //     })
-      //
-      //     // propertyGroups.selectAll()
-      //     //     .attr('transform', function (d, i ) {
-      //     //       return 'translate(' + _that.translationXOffset(d.position,
-      //     // x0) + ',0)'; });
-      //   }),
-      // )
+      //   .origin(function (d, i) {  // define the start drag as the middle of
+      // the group // this should match the transformation used when assigning
+      // the // group return {x: _that.translationXOffset(d.position, x0)} })
+      // .on('dragstart', function (d, i) { // track the position of the
+      // selected group in the dragging object dragging[d.key] =
+      // _that.translationXOffset(d.position, x0) var sel         =
+      // d3.select(this) sel.moveToFront() }) .on('drag', function (d, i) {//
+      // track current drag location dragging[d.key] = d3.event.x
+      // nested.sort(function (a, b) { return position(a, a.position, x0) -
+      // position(b, b.position, x0) })   ///rebuild the domain //TODO:  This
+      // is very not - DRY, copied from initial domain set. // should be
+      // factored out.  var rangeMapper   = {} var lengthTracker = 0 //keep
+      // track of where we are on the scale  nested.map(function (d, i) {  var
+      // groupSize = d.values.length * averageStepSize //   var location =
+      // lengthTracker + groupSize/2 //set the location // to the middle of its
+      // group var location = lengthTracker + // groupSize/2 //set the location
+      // to the middle of its group var location = lengthTracker //set the
+      // location to the start of its // group  rangeMapper[d.key]    =
+      // location lengthTracker += groupSize nested[i]['position'] = i })   x0
+      // = d3.scale.linear() .rangeRound(nested.map(function (d) { return
+      // rangeMapper[d.key] }))  // Set the domains based on the nested data
+      // x0.domain(nested.map(function (d, i) { return i }))
+      // propertyGroups.attr('transform', function (d) {  return 'translate(' +
+      // position(d, d.position, x0) + ', 0)' }) }) .on('dragend', function (d,
+      // i) { delete dragging[d.key]
+      // transition(d3.select(this)).attr('transform', function (d) { return
+      // 'translate(' + _that.translationXOffset(d.position, x0) + ',0)' })  //
+      // propertyGroups.selectAll() //     .attr('transform', function (d, i )
+      // { //       return 'translate(' + _that.translationXOffset(d.position,
+      // // x0) + ',0)'; }); }), )
 
       //plot the actual bars!!
 
@@ -538,6 +500,25 @@
         .style('transition', 'opacity .25s linear')
         .style('z-index', 999999)
 
+      var initialTooltip = d3
+        .select('body')
+        .append('div')
+        .attr('class', 'toolTip')
+        .attr('id', 'chart-tooltip')
+        .style('position', 'absolute')
+        .style('max-width', '100px')
+        .style('padding', '10px')
+        .style('font-size', '12px')
+        .style('font-family', 'Helvetica, Roboto, sans-serif')
+        .style('background', 'rgba(255, 255, 255, .9)')
+        .style('border', '1px solid rgba(0,0,0,.3)')
+        .style('border-radius', '5px')
+        .style('display', 'none')
+        .style('opacity', 0)
+        .style('transition', 'opacity .25s linear')
+        .style('z-index', 999999)
+        .html('Click for More Info')
+
       bars
         .on('mouseover', function (d, i) {
           d3.select(this).style('opacity', .5)
@@ -551,17 +532,27 @@
             .style('left', ($(this).offset().left - 260) + 'px')
             .style('top', ((d3.event.pageY - (200)) + 'px'))
 
-          // divTooltip.transition()
-          //   .duration(200)
-          //   .style('opacity', 1)
-          //   .style('display', 'block')
+
+          initialTooltip.transition()
+            .duration(200)
+            .style('opacity', 1)
+            .style('display', 'block')
 
           this.hoveredBar = d.node
         }).on('mouseout', function (d) {
         this.hoveredBar = null
+        initialTooltip.transition()
+          .duration(200)
+          .style('opacity', 0)
+          .style('display', 'none')
         d3.select(this).style('opacity', 1)
-      }).on('click', function() {
+      }).on('click', function () {
         console.log('clicked')
+        initialTooltip.transition()
+          .duration(200)
+          .style('opacity', 0)
+          .style('display', 'none')
+
         divTooltip.transition()
           .duration(200)
           .style('opacity', 1)
@@ -575,7 +566,7 @@
         }
 
         divTooltip.transition()
-          .duration(500)
+          .duration(200)
           .style('opacity', 0)
           .style('display', 'none')
       })

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -558,6 +558,10 @@
         }, 200)
       })
 
+      divTooltip.on('click', function() {
+        console.log('clciked')
+      })
+
       $(document).on('click', function (e) {
         if ($(this).parents('#chart-tooltip').length || $(this).attr('id') === 'chart-tooltip') {
           return

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -537,7 +537,8 @@
         .style('z-index', 999999)
 
       bars.on('mouseover', function (d, i) {
-        console.log(d, i, d3.event.target)
+        var bar = d3.event.target
+        bar.style('opacity', .8)
         var propTable = _that.buildPropertyTooltipTable(d)
         divTooltip.transition()
           .duration(200)
@@ -552,6 +553,10 @@
           .style('left', ($(this).offset().left - 200) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
       })
+        .on('mouseout', function () {
+          var bar = d3.event.target
+          bar.style('opacity', 1)
+        })
 
       $(document).on('click', function (e) {
         if ($(e.target).parents('#chart-tooltip').length || $(e.target).attr('id') === 'chart-tooltip') {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -523,7 +523,7 @@
         .on('mouseover', function (d, i) {
           d3.select(this).style('opacity', .5)
           initialTooltip
-            .style('left', ($(this).offset().left - 260) + 'px')
+            .style('left', ($(this).offset().left - (window.outerWidth / 2)) + 'px')
             .style('top', ((d3.event.pageY - (20)) + 'px'))
 
           initialTooltip.transition()

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -525,14 +525,18 @@
       bars
         .on('mouseover', function (d, i) {
           d3.select(this).style('opacity', .5)
+
+
           initialTooltip
             .style('left', ($(this).offset().left - 50) + 'px')
             .style('top', ((d3.event.pageY - (80)) + 'px'))
 
-          initialTooltip.transition()
-            .duration(200)
-            .style('opacity', 1)
-            .style('display', 'block')
+          if (this.activeBar !== d.node) {
+            initialTooltip.transition()
+              .duration(200)
+              .style('opacity', 1)
+              .style('display', 'block')
+          }
         }).on('mouseout', function (d) {
         initialTooltip.transition()
           .duration(200)
@@ -575,6 +579,7 @@
         if ($(e.target).parents('#chart-tooltip').length || $(e.target).attr('id') === 'chart-tooltip') {
           return
         }
+        this.activeBar = null
 
         divTooltip.transition()
           .duration(200)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -532,9 +532,9 @@
             .style('left', ($(this).offset().left - 260) + 'px')
             .style('top', ((d3.event.pageY - (200)) + 'px'))
 
-          var coordinates = d3.mouse(this)
-          initialTooltip.style('left', coordinates[0])
-            .style('top', coordinates[1])
+          initialTooltip
+            .style('left', ($(this).offset().left - 260) + 'px')
+            .style('top', ((d3.event.pageY - (200)) + 'px'))
 
 
           initialTooltip.transition()

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -536,13 +536,15 @@
         .style('transition', 'opacity .25s linear')
         .style('z-index', 999999)
 
-      bars.on('mouseover', function (d, i) {
-        d3.select(this).style('opacity', .5)
-      })
+      bars
+        .on('mouseover', function (d, i) {
+          d3.select(this).style('opacity', .5).style('pointer-events', 'visible')
+        })
         .on('mouseout', function () {
-          d3.select(this).style('opacity', 1)
+          d3.select(this).style('opacity', 1).style('pointer-events', 'none')
         })
         .on('click', function (d) {
+          console.log(d)
           var propTable = _that.buildPropertyTooltipTable(d)
           divTooltip.transition()
             .duration(200)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -544,7 +544,7 @@
           .style('display', 'block')
 
         divTooltip.html(
-          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'>' + d.name + '</a><br/>' +
+          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'">' + d.name + '</a><br/>' +
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -558,11 +558,8 @@
         }, 200)
       })
 
-      divTooltip.on('click', function() {
-        console.log('clciked')
-      })
-
       $(document).on('click', function (e) {
+        console.log(e.target)
         if ($(this).parents('#chart-tooltip').length || $(this).attr('id') === 'chart-tooltip') {
           return
         }

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -4,6 +4,7 @@
     attach: function (context, settings) {
       // Define variables
       this.activeBar        = null
+      this.hoveredBar       = null
       this.heatMapRaw       = JSON.parse(settings.heatMapRaw)
       this.selectedAnalysis = settings.selectedAnalysis
       this.feature_id       = settings.feature_id
@@ -539,11 +540,8 @@
 
       bars
         .on('mouseover', function (d, i) {
+          d3.select(this).style('pointer-events', 'auto')
           var propTable = _that.buildPropertyTooltipTable(d)
-          divTooltip.transition()
-            .duration(200)
-            .style('opacity', 1)
-            .style('display', 'block')
 
           divTooltip.html(
             '<strong>Biosample:</strong> <a href="/bio_data/' + d.node + '">' + d.name + '</a><br/>' +
@@ -552,9 +550,25 @@
             + propTable)
             .style('left', ($(this).offset().left - 260) + 'px')
             .style('top', ((d3.event.pageY - (200)) + 'px'))
-        })
+
+          // divTooltip.transition()
+          //   .duration(200)
+          //   .style('opacity', 1)
+          //   .style('display', 'block')
+
+          this.hoveredBar = d.node
+        }).on('mouseout', function (d) {
+        this.hoveredBar = null
+      }).on('click', function() {
+        console.log('clicked')
+        divTooltip.transition()
+          .duration(200)
+          .style('opacity', 1)
+          .style('display', 'block')
+      })
 
       $(document).on('click', function (e) {
+
         if ($(e.target).parents('#chart-tooltip').length || $(e.target).attr('id') === 'chart-tooltip') {
           return
         }

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -524,7 +524,7 @@
           d3.select(this).style('opacity', .5)
           initialTooltip
             .style('left', ($(this).offset().left - 100) + 'px')
-            .style('top', ((d3.event.pageY - (100)) + 'px'))
+            .style('top', ((d3.event.pageY - (80)) + 'px'))
 
           initialTooltip.transition()
             .duration(200)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -543,10 +543,8 @@
           .style('opacity', 1)
           .style('display', 'block')
 
-        console.log(d)
-
         divTooltip.html(
-          '<strong>Biosample:</strong> <a href="">' + d.name + '</a><br/>' +
+          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'>' + d.name + '</a><br/>' +
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -517,8 +517,11 @@
 
 //Add the tool tip
 
-      var divTooltip = d3.select('body').append('div')
+      var divTooltip = d3
+        .select('body')
+        .append('div')
         .attr('class', 'toolTip')
+        .attr('id', 'chart-tooltip')
         .style('position', 'absolute')
         .style('max-width', '250px')
         .style('padding', '10px')
@@ -556,11 +559,7 @@
       })
 
       $(document).on('click', function (e) {
-        if (e.target && e.target.contains(divTooltip[0])) {
-          return
-        }
-
-        if (e.target && e.target === divTooltip[0]) {
+        if ($(this).parents('#chart-tooltip') || $(this).attr('id') === 'chart-tooltip') {
           return
         }
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -543,8 +543,10 @@
           .style('opacity', 1)
           .style('display', 'block')
 
+        console.log(d)
+
         divTooltip.html(
-          '<strong>Biosample:</strong> ' + d.name + '<br/>' +
+          '<strong>Biosample:</strong> <a href="">' + d.name + '</a><br/>' +
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -548,12 +548,14 @@
           .style('left', ($(this).offset().left - 260) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
       })
-        .on('mouseout', function (d) {
-          divTooltip.transition()
-            .duration(500)
-            .style('opacity', 0)
-            .style('display', 'none')
-        })
+
+      document.on('mouseout', function (d) {
+        console.log(divTooltip)
+        divTooltip.transition()
+          .duration(500)
+          .style('opacity', 0)
+          .style('display', 'none')
+      })
 
       this.buildLegend(color, calculatedWidth, margin, height)
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -317,7 +317,7 @@
       d3.select('figure')
         .style('overflow', 'auto')
         .style('max-width', '100%')
-        .on('scroll', function() {
+        .on('scroll', function () {
           $(document).trigger($.Event('figure.scroll'))
         })
 
@@ -543,6 +543,15 @@
           .style('display', 'none')
         d3.select(this).style('opacity', 1)
       }).on('click', function (d) {
+        if (this.activeBar === d.node) {
+          divTooltip.transition()
+            .duration(200)
+            .style('opacity', 0)
+            .style('display', 'none')
+          this.activeBar = null
+          return
+        }
+        this.activeBar = d.node
         initialTooltip.transition()
           .duration(200)
           .style('opacity', 0)
@@ -557,7 +566,7 @@
           + propTable)
           .style('left', ($(this).offset().left - 260) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
-        setTimeout(function() {
+        setTimeout(function () {
           divTooltip.transition()
             .duration(200)
             .style('opacity', 1)
@@ -576,7 +585,7 @@
           .style('display', 'none')
       })
 
-      $(document).on('figure.scroll', function() {
+      $(document).on('figure.scroll', function () {
         divTooltip.transition()
           .duration(200)
           .style('opacity', 0)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -567,15 +567,15 @@
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)
-          .style('left', ($(this).offset().left - 260) + 'px')
-          .style('top', ((d3.event.pageY - (200)) + 'px'))
+          .css('left', ($(this).offset().left - 260) + 'px')
+          .css('top', ((d3.event.pageY - (200)) + 'px'))
 
         divTooltip.fadeIn()
 
         let pos = d3.event.pageY
         setTimeout(function () {
           var height = divTooltip[0].outerHeight / 2
-          divTooltip.style('top', ((pos - height) + 'px'))
+          divTooltip.css('top', ((pos - height) + 'px'))
         }, 200)
       })
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -577,7 +577,10 @@
       })
 
       $(document).on('figure.scroll', function() {
-        console.log('scrolling')
+        divTooltip.transition()
+          .duration(200)
+          .style('opacity', 0)
+          .style('display', 'none')
       })
 
       this.buildLegend(color, calculatedWidth, margin, height)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -517,66 +517,44 @@
 
 //Add the tool tip
 
-      // var divTooltip = d3
-      //   .select('body')
-      //   .append('div')
-      //   .attr('class', 'toolTip')
-      //   .attr('id', 'chart-tooltip')
-      //   .style('position', 'absolute')
-      //   .style('max-width', '250px')
-      //   .style('padding', '10px')
-      //   .style('font-size', '12px')
-      //   .style('font-family', 'Helvetica, Roboto, sans-serif')
-      //   .style('background', 'rgba(255, 255, 255, .9)')
-      //   .style('border', '1px solid rgba(0,0,0,.3)')
-      //   .style('border-radius', '5px')
-      //   .style('pointer-events', 'none')
-      //   .style('display', 'none')
-      //   .style('opacity', 0)
-      //   .style('transition', 'opacity .25s linear')
-      //   .style('z-index', 9999999999)
-
-      var divTooltip = $('<div />')
-        .addClass('toolTip')
+      var divTooltip = d3
+        .select('body')
+        .append('div')
+        .attr('class', 'toolTip')
         .attr('id', 'chart-tooltip')
-        .css('position', 'absolute')
-        .css('max-width', '250px')
-        .css('padding', '10px')
-        .css('font-size', '12px')
-        .css('font-family', 'Helvetica, Roboto, sans-serif')
-        .css('background', 'rgba(255, 255, 255, .9)')
-        .css('border', '1px solid rgba(0,0,0,.3)')
-        .css('border-radius', '5px')
-        // .css('pointer-events', 'none')
-        .css('display', 'none')
-        // .css('opacity', 0)
-        .css('transition', 'opacity .25s linear')
-        .css('z-index', 9999999999)
-
-      $('body').append(divTooltip)
+        .style('position', 'absolute')
+        .style('max-width', '250px')
+        .style('padding', '10px')
+        .style('font-size', '12px')
+        .style('font-family', 'Helvetica, Roboto, sans-serif')
+        .style('background', 'rgba(255, 255, 255, .9)')
+        .style('border', '1px solid rgba(0,0,0,.3)')
+        .style('border-radius', '5px')
+        // .style('pointer-events', 'none')
+        .style('display', 'none')
+        .style('opacity', 0)
+        .style('transition', 'opacity .25s linear')
+        .style('z-index', 999999)
 
       bars.on('mouseover', function (d) {
         var propTable = _that.buildPropertyTooltipTable(d)
-        // divTooltip.transition()
-        //   .duration(200)
-        //   .style('opacity', 1)
-        //   .style('display', 'block')
+        divTooltip.transition()
+          .duration(200)
+          .style('opacity', 1)
+          .style('display', 'block')
 
         divTooltip.html(
-          '<strong>Biosample:</strong> <a href="/bio_data/' + d.node + '">' + d.name + '</a><br/>' +
+          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'">' + d.name + '</a><br/>' +
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)
-          .css('left', ($(this).offset().left - 260) + 'px')
-          .css('top', ((d3.event.pageY - (200)) + 'px'))
-
-        divTooltip.fadeIn()
-        console.log(divTooltip)
+          .style('left', ($(this).offset().left - 260) + 'px')
+          .style('top', ((d3.event.pageY - (200)) + 'px'))
 
         let pos = d3.event.pageY
         setTimeout(function () {
           var height = divTooltip[0].outerHeight / 2
-          divTooltip.css('top', ((pos - height) + 'px'))
+          divTooltip.style('top', ((pos - height) + 'px'))
         }, 200)
       })
 
@@ -585,12 +563,10 @@
           return
         }
 
-        divTooltip.fadeOut()
-
-        // divTooltip.transition()
-        //   .duration(500)
-        //   .style('opacity', 0)
-        //   .style('display', 'none')
+        divTooltip.transition()
+          .duration(500)
+          .style('opacity', 0)
+          .style('display', 'none')
       })
 
       this.buildLegend(color, calculatedWidth, margin, height)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -559,7 +559,7 @@
             .duration(200)
             .style('opacity', 1)
             .style('display', 'block')
-        }, 500)
+        }, 200)
       })
 
       $(document).on('click', function (e) {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -538,7 +538,7 @@
 
       bars.on('mouseover', function (d, i) {
         var bar = d3.event.target
-        bar.style('opacity', .8)
+        $(bar).css('opacity', .8)
         var propTable = _that.buildPropertyTooltipTable(d)
         divTooltip.transition()
           .duration(200)
@@ -555,7 +555,7 @@
       })
         .on('mouseout', function () {
           var bar = d3.event.target
-          bar.style('opacity', 1)
+          $(bar).css('opacity', 1)
         })
 
       $(document).on('click', function (e) {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -549,7 +549,7 @@
         .css('border-radius', '5px')
         .css('pointer-events', 'none')
         .css('display', 'none')
-        .css('opacity', 0)
+        // .css('opacity', 0)
         .css('transition', 'opacity .25s linear')
         .css('z-index', 9999999999)
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -541,7 +541,7 @@
           d3.select(this).style('opacity', .5).style('pointer-events', 'visible')
         })
         .on('mouseout', function () {
-          d3.select(this).style('opacity', 1).style('pointer-events', 'none')
+          d3.select(this).style('opacity', 1)
         })
         .on('click', function (d) {
           console.log(d)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -571,6 +571,7 @@
           .css('top', ((d3.event.pageY - (200)) + 'px'))
 
         divTooltip.fadeIn()
+        console.log(divTooltip)
 
         let pos = d3.event.pageY
         setTimeout(function () {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -548,10 +548,11 @@
           .style('left', ($(this).offset().left - 260) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
 
+        let pos = d3.event.pageY
         setTimeout(function() {
           var height = divTooltip[0].outerHeight / 2
-            divTooltip.style('top', ((d3.event.pageY - height) + 'px'))
-        })
+            divTooltip.style('top', ((pos - height) + 'px'))
+        }, 200)
         console.log(divTooltip[0])
       })
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -536,7 +536,8 @@
         .style('transition', 'opacity .25s linear')
         .style('z-index', 999999)
 
-      bars.on('mouseover', function (d) {
+      bars.on('mouseover', function (d, i) {
+        console.log(d, i)
         var propTable = _that.buildPropertyTooltipTable(d)
         divTooltip.transition()
           .duration(200)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -540,7 +540,7 @@
 
       bars
         .on('mouseover', function (d, i) {
-          d3.select(this).style('pointer-events', 'auto')
+          d3.select(this).style('opacity', .5)
           var propTable = _that.buildPropertyTooltipTable(d)
 
           divTooltip.html(
@@ -559,6 +559,7 @@
           this.hoveredBar = d.node
         }).on('mouseout', function (d) {
         this.hoveredBar = null
+        d3.select(this).style('opacity', 1)
       }).on('click', function() {
         console.log('clicked')
         divTooltip.transition()

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -548,7 +548,7 @@
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)
-          .style('left', ($(this).offset().left - 260) + 'px')
+          .style('left', ($(this).offset().left - 200) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
       })
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -568,7 +568,7 @@
       })
 
       $(document).on('click', function (e) {
-
+        console.log(e.target)
         if ($(e.target).parents('#chart-tooltip').length || $(e.target).attr('id') === 'chart-tooltip') {
           return
         }

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -506,7 +506,7 @@
         .attr('class', 'toolTip')
         .attr('id', 'chart-tooltip')
         .style('position', 'absolute')
-        .style('max-width', '100px')
+        .style('width', '100px')
         .style('padding', '10px')
         .style('font-size', '12px')
         .style('font-family', 'Helvetica, Roboto, sans-serif')
@@ -522,20 +522,9 @@
       bars
         .on('mouseover', function (d, i) {
           d3.select(this).style('opacity', .5)
-          var propTable = _that.buildPropertyTooltipTable(d)
-
-          divTooltip.html(
-            '<strong>Biosample:</strong> <a href="/bio_data/' + d.node + '">' + d.name + '</a><br/>' +
-            '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
-            '<strong>Description: </strong><br/>' + d.description + '<br/>'
-            + propTable)
-            .style('left', ($(this).offset().left - 260) + 'px')
-            .style('top', ((d3.event.pageY - (200)) + 'px'))
-
           initialTooltip
             .style('left', ($(this).offset().left - 260) + 'px')
             .style('top', ((d3.event.pageY - (200)) + 'px'))
-
 
           initialTooltip.transition()
             .duration(200)
@@ -550,13 +539,21 @@
           .style('opacity', 0)
           .style('display', 'none')
         d3.select(this).style('opacity', 1)
-      }).on('click', function () {
-        console.log('clicked')
+      }).on('click', function (d) {
         initialTooltip.transition()
           .duration(200)
           .style('opacity', 0)
           .style('display', 'none')
 
+        var propTable = _that.buildPropertyTooltipTable(d)
+
+        divTooltip.html(
+          '<strong>Biosample:</strong> <a href="/bio_data/' + d.node + '">' + d.name + '</a><br/>' +
+          '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
+          '<strong>Description: </strong><br/>' + d.description + '<br/>'
+          + propTable)
+          .style('left', ($(this).offset().left - 260) + 'px')
+          .style('top', ((d3.event.pageY - (200)) + 'px'))
         divTooltip.transition()
           .duration(200)
           .style('opacity', 1)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -537,12 +537,10 @@
         .style('z-index', 999999)
 
       bars.on('mouseover', function (d, i) {
-        var bar = d3.event.target
-        $(bar).css('opacity', .8)
+        d3.select(this).style('opacity', .5)
       })
         .on('mouseout', function () {
-          var bar = d3.event.target
-          $(bar).css('opacity', 1)
+          d3.select(this).style('opacity', 1)
         })
         .on('click', function (d) {
           var propTable = _that.buildPropertyTooltipTable(d)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -547,6 +547,12 @@
           + propTable)
           .style('left', ($(this).offset().left - 260) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
+
+        setTimeout(function() {
+          var height = divTooltip[0].outerHeight / 2
+            divTooltip.style('top', ((d3.event.pageY - height) + 'px'))
+        })
+        console.log(divTooltip[0])
       })
 
       $(document).on('click', function (d) {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -560,7 +560,6 @@
       })
 
       $(document).on('click', function (e) {
-        console.log(e.target)
         if ($(e.target).parents('#chart-tooltip').length || $(e.target).attr('id') === 'chart-tooltip') {
           return
         }

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -534,7 +534,7 @@
         .style('display', 'none')
         .style('opacity', 0)
         .style('transition', 'opacity .25s linear')
-        .style('z-index', 999999)
+        .style('z-index', 9999999999)
 
       bars.on('mouseover', function (d) {
         var propTable = _that.buildPropertyTooltipTable(d)
@@ -544,7 +544,7 @@
           .style('display', 'block')
 
         divTooltip.html(
-          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'" onclick="alert(\'clicked\')">' + d.name + '</a><br/>' +
+          '<strong>Biosample:</strong> <a href="/bio_data/'+d.node+'">' + d.name + '</a><br/>' +
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -559,8 +559,7 @@
       })
 
       $(document).on('click', function (e) {
-        console.log($(this), $(this).parents('#chart-tooltip'), $(this).attr('id') === 'chart-tooltip')
-        if ($(this).parents('#chart-tooltip') || $(this).attr('id') === 'chart-tooltip') {
+        if ($(this).parents('#chart-tooltip').length || $(this).attr('id') === 'chart-tooltip') {
           return
         }
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -537,7 +537,7 @@
         .style('z-index', 999999)
 
       bars.on('mouseover', function (d, i) {
-        console.log(d, i)
+        console.log(d, i, d3.event.target)
         var propTable = _that.buildPropertyTooltipTable(d)
         divTooltip.transition()
           .duration(200)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -539,23 +539,25 @@
       bars.on('mouseover', function (d, i) {
         var bar = d3.event.target
         $(bar).css('opacity', .8)
-        var propTable = _that.buildPropertyTooltipTable(d)
-        // divTooltip.transition()
-        //   .duration(200)
-        //   .style('opacity', 1)
-        //   .style('display', 'block')
-
-        divTooltip.html(
-          '<strong>Biosample:</strong> <a href="/bio_data/' + d.node + '">' + d.name + '</a><br/>' +
-          '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
-          '<strong>Description: </strong><br/>' + d.description + '<br/>'
-          + propTable)
-          .style('left', ($(this).offset().left - 260) + 'px')
-          .style('top', ((d3.event.pageY - (200)) + 'px'))
       })
         .on('mouseout', function () {
           var bar = d3.event.target
           $(bar).css('opacity', 1)
+        })
+        .on('click', function (d) {
+          var propTable = _that.buildPropertyTooltipTable(d)
+          divTooltip.transition()
+            .duration(200)
+            .style('opacity', 1)
+            .style('display', 'block')
+
+          divTooltip.html(
+            '<strong>Biosample:</strong> <a href="/bio_data/' + d.node + '">' + d.name + '</a><br/>' +
+            '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
+            '<strong>Description: </strong><br/>' + d.description + '<br/>'
+            + propTable)
+            .style('left', ($(this).offset().left - 260) + 'px')
+            .style('top', ((d3.event.pageY - (200)) + 'px'))
         })
 
       $(document).on('click', function (e) {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -559,6 +559,7 @@
       })
 
       $(document).on('click', function (e) {
+        console.log($(this))
         if ($(this).parents('#chart-tooltip') || $(this).attr('id') === 'chart-tooltip') {
           return
         }

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -547,7 +547,7 @@
         .css('background', 'rgba(255, 255, 255, .9)')
         .css('border', '1px solid rgba(0,0,0,.3)')
         .css('border-radius', '5px')
-        .css('pointer-events', 'none')
+        // .css('pointer-events', 'none')
         .css('display', 'none')
         // .css('opacity', 0)
         .css('transition', 'opacity .25s linear')

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -523,7 +523,7 @@
         .on('mouseover', function (d, i) {
           d3.select(this).style('opacity', .5)
           initialTooltip
-            .style('left', ($(this).offset().left - (window.outerWidth / 2)) + 'px')
+            .style('left', ($(this).offset().left - 20) + 'px')
             .style('top', ((d3.event.pageY - (20)) + 'px'))
 
           initialTooltip.transition()

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -392,75 +392,75 @@
       })
 
 
-      propertyGroups.call(d3.behavior.drag()
-        .origin(function (d, i) {  // define the start drag as the middle of the group
-          // this should match the transformation used when assigning the
-          // group
-          return {x: _that.translationXOffset(d.position, x0)}
-        })
-        .on('dragstart', function (d, i) {
-          // track the position of the selected group in the dragging object
-          dragging[d.key] = _that.translationXOffset(d.position, x0)
-          var sel         = d3.select(this)
-          sel.moveToFront()
-        })
-        .on('drag', function (d, i) {// track current drag location
-          dragging[d.key] = d3.event.x
-
-          nested.sort(function (a, b) {
-            return position(a, a.position, x0) - position(b, b.position, x0)
-          })
-
-
-          ///rebuild the domain
-          //TODO:  This is very not - DRY, copied from initial domain set.
-          // should be factored out.
-
-          var rangeMapper   = {}
-          var lengthTracker = 0 //keep track of where we are on the scale
-
-          nested.map(function (d, i) {
-
-            var groupSize = d.values.length * averageStepSize
-            //   var location = lengthTracker + groupSize/2 //set the location
-            // to the middle of its group var location = lengthTracker +
-            // groupSize/2 //set the location to the middle of its group
-            var location = lengthTracker //set the location to the start of its
-            // group
-
-            rangeMapper[d.key]    = location
-            lengthTracker += groupSize
-            nested[i]['position'] = i
-          })
-
-
-          x0 = d3.scale.linear()
-            .rangeRound(nested.map(function (d) {
-              return rangeMapper[d.key]
-            }))
-
-          // Set the domains based on the nested data
-          x0.domain(nested.map(function (d, i) {
-            return i
-          }))
-
-          propertyGroups.attr('transform', function (d) {
-
-            return 'translate(' + position(d, d.position, x0) + ', 0)'
-          })
-        })
-        .on('dragend', function (d, i) {
-          delete dragging[d.key]
-          transition(d3.select(this)).attr('transform', function (d) {
-            return 'translate(' + _that.translationXOffset(d.position, x0) + ',0)'
-          })
-
-          // propertyGroups.selectAll()
-          //     .attr('transform', function (d, i ) {
-          //       return 'translate(' + _that.translationXOffset(d.position,
-          // x0) + ',0)'; });
-        }),
-      )
+      // propertyGroups.call(d3.behavior.drag()
+      //   .origin(function (d, i) {  // define the start drag as the middle of the group
+      //     // this should match the transformation used when assigning the
+      //     // group
+      //     return {x: _that.translationXOffset(d.position, x0)}
+      //   })
+      //   .on('dragstart', function (d, i) {
+      //     // track the position of the selected group in the dragging object
+      //     dragging[d.key] = _that.translationXOffset(d.position, x0)
+      //     var sel         = d3.select(this)
+      //     sel.moveToFront()
+      //   })
+      //   .on('drag', function (d, i) {// track current drag location
+      //     dragging[d.key] = d3.event.x
+      //
+      //     nested.sort(function (a, b) {
+      //       return position(a, a.position, x0) - position(b, b.position, x0)
+      //     })
+      //
+      //
+      //     ///rebuild the domain
+      //     //TODO:  This is very not - DRY, copied from initial domain set.
+      //     // should be factored out.
+      //
+      //     var rangeMapper   = {}
+      //     var lengthTracker = 0 //keep track of where we are on the scale
+      //
+      //     nested.map(function (d, i) {
+      //
+      //       var groupSize = d.values.length * averageStepSize
+      //       //   var location = lengthTracker + groupSize/2 //set the location
+      //       // to the middle of its group var location = lengthTracker +
+      //       // groupSize/2 //set the location to the middle of its group
+      //       var location = lengthTracker //set the location to the start of its
+      //       // group
+      //
+      //       rangeMapper[d.key]    = location
+      //       lengthTracker += groupSize
+      //       nested[i]['position'] = i
+      //     })
+      //
+      //
+      //     x0 = d3.scale.linear()
+      //       .rangeRound(nested.map(function (d) {
+      //         return rangeMapper[d.key]
+      //       }))
+      //
+      //     // Set the domains based on the nested data
+      //     x0.domain(nested.map(function (d, i) {
+      //       return i
+      //     }))
+      //
+      //     propertyGroups.attr('transform', function (d) {
+      //
+      //       return 'translate(' + position(d, d.position, x0) + ', 0)'
+      //     })
+      //   })
+      //   .on('dragend', function (d, i) {
+      //     delete dragging[d.key]
+      //     transition(d3.select(this)).attr('transform', function (d) {
+      //       return 'translate(' + _that.translationXOffset(d.position, x0) + ',0)'
+      //     })
+      //
+      //     // propertyGroups.selectAll()
+      //     //     .attr('transform', function (d, i ) {
+      //     //       return 'translate(' + _that.translationXOffset(d.position,
+      //     // x0) + ',0)'; });
+      //   }),
+      // )
 
       //plot the actual bars!!
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -540,17 +540,17 @@
         var bar = d3.event.target
         $(bar).css('opacity', .8)
         var propTable = _that.buildPropertyTooltipTable(d)
-        divTooltip.transition()
-          .duration(200)
-          .style('opacity', 1)
-          .style('display', 'block')
+        // divTooltip.transition()
+        //   .duration(200)
+        //   .style('opacity', 1)
+        //   .style('display', 'block')
 
         divTooltip.html(
           '<strong>Biosample:</strong> <a href="/bio_data/' + d.node + '">' + d.name + '</a><br/>' +
           '<strong>Expression: </strong>' + d.intensity + ' ' + d.units + '<br/>' +
           '<strong>Description: </strong><br/>' + d.description + '<br/>'
           + propTable)
-          .style('left', ($(this).offset().left - 200) + 'px')
+          .style('left', ($(this).offset().left - 260) + 'px')
           .style('top', ((d3.event.pageY - (200)) + 'px'))
       })
         .on('mouseout', function () {

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -317,6 +317,9 @@
       d3.select('figure')
         .style('overflow', 'auto')
         .style('max-width', '100%')
+        .on('scroll', function() {
+          console.log('scrolling')
+        })
 
       var svg = d3.select('figure')
         .append('chart')

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -532,6 +532,10 @@
             .style('left', ($(this).offset().left - 260) + 'px')
             .style('top', ((d3.event.pageY - (200)) + 'px'))
 
+          var coordinates = d3.mouse(this)
+          initialTooltip.style('left', coordinates[0])
+            .style('top', coordinates[1])
+
 
           initialTooltip.transition()
             .duration(200)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -533,10 +533,7 @@
             .duration(200)
             .style('opacity', 1)
             .style('display', 'block')
-
-          this.hoveredBar = d.node
         }).on('mouseout', function (d) {
-        this.hoveredBar = null
         initialTooltip.transition()
           .duration(200)
           .style('opacity', 0)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -350,15 +350,16 @@
       propertyGroups.append('g')
         .attr()
         .append('rect')
-        .style('fill', 'black')
-        .attr('y', height - (margin.bottom - 1))
+        .style('fill', '#444')
+        .style('border-radius', '3px')
+        .attr('y', height - (margin.bottom - 2))
         .attr('x', barwidth / 2)
         .attr('width', function (d) {
           var length = d.values.length * (barwidth + barSpacing) - barwidth * 1.5
           return length > barwidth ? length : 1
 
         })
-        .attr('height', 1)
+        .attr('height', 2)
 
 
       var text = propertyGroups.append('text')

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -524,7 +524,7 @@
           d3.select(this).style('opacity', .5)
           initialTooltip
             .style('left', ($(this).offset().left - 260) + 'px')
-            .style('top', ((d3.event.pageY - (200)) + 'px'))
+            .style('top', ((d3.event.pageY - (20)) + 'px'))
 
           initialTooltip.transition()
             .duration(200)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -503,8 +503,8 @@
       var initialTooltip = d3
         .select('body')
         .append('div')
-        .attr('class', 'toolTip')
-        .attr('id', 'chart-tooltip')
+        .attr('class', 'init-tooltip')
+        .attr('id', 'init-tooltip')
         .style('position', 'absolute')
         .style('width', '100px')
         .style('padding', '10px')

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -581,8 +581,7 @@
       })
 
       $(document).on('click', function (e) {
-        console.log(e.target)
-        if ($(this).parents('#chart-tooltip').length || $(this).attr('id') === 'chart-tooltip') {
+        if ($(e.target).parents('#chart-tooltip').length || $(e.target).attr('id') === 'chart-tooltip') {
           return
         }
 

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -553,7 +553,7 @@
         .css('transition', 'opacity .25s linear')
         .css('z-index', 9999999999)
 
-      $('body').prepend(divTooltip)
+      $('body').append(divTooltip)
 
       bars.on('mouseover', function (d) {
         var propTable = _that.buildPropertyTooltipTable(d)

--- a/tripal_analysis_expression/theme/js/expression.js
+++ b/tripal_analysis_expression/theme/js/expression.js
@@ -523,7 +523,7 @@
         .on('mouseover', function (d, i) {
           d3.select(this).style('opacity', .5)
           initialTooltip
-            .style('left', ($(this).offset().left - 100) + 'px')
+            .style('left', ($(this).offset().left - 50) + 'px')
             .style('top', ((d3.event.pageY - (80)) + 'px'))
 
           initialTooltip.transition()


### PR DESCRIPTION
Various improvements to the expression chart
- Don't hide the tooltip when users move away from the bar
- Allow users to click through to biosmaple page from the tooltip
- Bars now show up on click instead so they don't obstruct the view when not necessary 
