### PR TITLE
P-value loader issues and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To upload the file into Chado/Tripal, navigate to:
 First, provide the path on the server to the biosample file, or use the file uploader. You must select an Organism to associate the biosamples with.  You may also associate the imported biosamples with an analysis, but this is not required.
 
 Press the **Check Biosamples** button to preview your biosample properties.  To take advantage of a controlled vocabulary (CV), you must manually assign each property to a CVterm.  The uploader will list all CV terms matching each property, and provide the CV, database (DB) and accession for the match.
-If a match does not exist for your term, use the CVterm browser to identify an appropriate CVterm in your Tripal site, and rename the property in your input file to match the term.  If no term exists in your database, you should use the EBI ontology lookup serice to identify an appropriate term and insert it manually, or, load the corresponding CV.
+If a match does not exist for your term, use the CVterm browser to identify an appropriate CVterm in your Tripal site, and rename the property in your input file to match the term.  If no term exists in your database, you should use the EBI ontology lookup service to identify an appropriate term and insert it manually, or, load the corresponding CV.
 
 > ![The Biosample property configuration tool](example_files/doc_images/biosample_prop_checker.png)
 > Pressing the 'Check Biosamples' button allows you to assign CVterms to every biosample property in your upload.  If there isn't a suitable CVterm, you should rename it in your upload file to match a CVterm in the database and/or insert new CVterms.
@@ -103,7 +103,7 @@ After clicking "Submit job", the page should reload with the job status and Drus
 
 ### Loading Biosamples From a Flat File
 
-Altenatively biosamples may be loaded from a flat file (CSV or TSV). The flat file loader is designed to upload files that are in the [NCBI BioSample submission format](https://submit.ncbi.nlm.nih.gov/biosample/template/) which can be downloaded [here](https://submit.ncbi.nlm.nih.gov/biosample/template/). Download the TSV version of the file. The file must have a header that specifies the type of data in the column. There must be one column labeled "sample\_name". The loader will begin to collect data from the line that follows the line containing "sample\_name" which is assumed to be the header line. Columns are not required to be in any order. Other columns will be either attributes or accessions. Available NCBI [attributes](https://submit.ncbi.nlm.nih.gov/biosample/template/) can be found [here](https://submit.ncbi.nlm.nih.gov/biosample/template/). Available accession headers are bioproject\_accession, sra\_accession, biosample\_accession. All other columns will be uploaded as properties. To upload other accessions use the bulk loader provided with this module labeled, "Biomaterial Accession Term Loader". This loader will load a flat file with 3 columns (sample name, database name, accession term). A Tripal database must be created with the same name as the database name in the upload file.
+Alternatively biosamples may be loaded from a flat file (CSV or TSV). The flat file loader is designed to upload files that are in the [NCBI BioSample submission format](https://submit.ncbi.nlm.nih.gov/biosample/template/) which can be downloaded [here](https://submit.ncbi.nlm.nih.gov/biosample/template/). Download the TSV version of the file. The file must have a header that specifies the type of data in the column. There must be one column labeled "sample\_name". The loader will begin to collect data from the line that follows the line containing "sample\_name" which is assumed to be the header line. Columns are not required to be in any order. Other columns will be either attributes or accessions. Available NCBI [attributes](https://submit.ncbi.nlm.nih.gov/biosample/template/) can be found [here](https://submit.ncbi.nlm.nih.gov/biosample/template/). Available accession headers are bioproject\_accession, sra\_accession, biosample\_accession. All other columns will be uploaded as properties. To upload other accessions use the bulk loader provided with this module labeled, "Biomaterial Accession Term Loader". This loader will load a flat file with 3 columns (sample name, database name, accession term). A Tripal database must be created with the same name as the database name in the upload file.
 
 Click here to see an example of a [CSV file](example_files/exampleCSV.csv) and a [TSV file](example_files/exampleTSV.tsv).
 
@@ -127,7 +127,7 @@ If there are multiple sequencing runs associated with the same biosample that sh
 
 ![image](https://user-images.githubusercontent.com/43583505/87336786-669dfd00-c510-11ea-8171-86c83e3ce253.png)
 
-4) Click metadata to download the csv flie 
+4) Click metadata to download the csv file 
   
 ![image](https://user-images.githubusercontent.com/43583505/87336991-b7adf100-c510-11ea-963a-4caabee6a2e2.png)
 
@@ -138,7 +138,7 @@ If there are multiple sequencing runs associated with the same biosample that sh
 After loading, biosamples must be published to create entities for each biosample content type. As an administrator or user with correct permissions, navigate to **Content->Tripal Content->Publish Tripal Content**. Select the biological sample type to publish, apply any optional filtering, and press Publish.
 
 ### Loading a Single Biosample
-Biosamples may also be loaded one at a time. As an administer or a user with permission to create Tripal content, go to: **Content->Tripal Content -> Add Tripal Content -> Biological Sample**. Available biosamples fields include the following.
+Biosamples may also be loaded one at a time. As an administrator or a user with permission to create Tripal content, go to: **Content->Tripal Content -> Add Tripal Content -> Biological Sample**. Available biosamples fields include the following.
 * **Accession** - If the biosample is in a database stored in your Tripal site, the accession can be entered here.
 * **Name (must be unique - required)**
 * **Description** - A description of the biosample.
@@ -167,7 +167,7 @@ The steps for loading expression data are as follows (detailed instructions can 
 1. Obtain expression data. Click [here to read about the file formats accepted for expression data](#data-loader).
 2. Add the organism associated with the expression data if it hasn't been added.
 3. Upload all features in the expression data to the Chado database. To bulk upload features, go to **Tripal->Data Loaders->Chado FASTA Loader** and upload a FASTA file (click here to see an example of [fasta file of transcriptome sequences](http://www.hardwoodgenomics.org/sites/default/files/sequences/sugarMaple022416/Acer_saccharum_022416_transcripts.fasta)). Or upload one feature at a time via **content-> Tripal Content -> Add content**, and select the relevant entity type (such as mRNA).
-4. Load the espression data.  This is also the step where you can add experimental design details.
+4. Load the expression data.  This is also the step where you can add experimental design details.
 
 ### Creating the Analysis
 Before loading data, describe the experimental setup used to collect the data. As an administrator or a user with permission to create content, navigate to content -> tripal content -> Analysis.
@@ -188,7 +188,7 @@ Before loading data, describe the experimental setup used to collect the data. A
 
 #### Expression Data Loader
 
-The Chado Expression Data Loader provide a way for the user to load expression data associated with the experiment. The loader can load data from two types of formats, matrix and column. The matrix format expects a row of data containing biosample names. The first column should be unique feature names. Features must already be loaded into the database. Biosamples will be added if not present. Expression values will map to a biosample library in the column and a feature in the row. Only one matrix file may be loaded at a time. The column format expects the first column to contain features and the second column to be expression values.
+The Chado Expression Data Loader provides a way for the user to load expression data associated with the experiment. The loader can load data from two types of formats, matrix and column. The matrix format expects a row of data containing biosample names. The first column should be unique feature names. Features must already be loaded into the database. Biosamples will be added if not present. Expression values will map to a biosample library in the column and a feature in the row. Only one matrix file may be loaded at a time. The column format expects the first column to contain features and the second column to be expression values.
 
 For an example column file, click [here](example_files/exampleExpressionData.rpkm). For an example matrix file, click [here](example_files/exampleMatrix.tsv).
 
@@ -202,12 +202,12 @@ The biosample name will be taken as the name of the file minus the file extensio
 * **Name Match Type** - Will the data be associated with feature names or unique names?
 * **File Type Suffix** - The suffix of the files to load. This is used to submit multiple column format files in the same directory. A suffix is not required for a matrix file.
 * **Regex for Start of Data** - If the expression file has a header, use this field to capture the line that occurs before the start of expression data. This line of text and any text preceding this line will be ignored.
-* **Regex for End of Data** - If the expression file has a footer, use this field to capture teh line that occurs after the end of expression data. This line of text and all text following will be ignored.
+* **Regex for End of Data** - If the expression file has a footer, use this field to capture the line that occurs after the end of expression data. This line of text and all text following will be ignored.
 
 #### Experimental Design Fields
 The "Experimental Design" fields allow a complete description of the experimental design by implementing the [Chado MAGE design schema](http://gmod.org/wiki/Chado_Mage_Module).  The Chado MAGE module uses the arraydesign, assay, quantification, and acquisition tables to describe an experiment. The Tripal Analysis Expression creates generic instances of all these for you.
 
-* **Array Design** - This is only applicable for microarray expression data. This may be left blank for experiments that do not utilize an array (ie next generation sequencing).
+* **Array Design** - This is only applicable for microarray expression data. This may be left blank for experiments that do not utilize an array (i.e. next generation sequencing).
 * **Units** - The units associated with the loaded values, such as FPKM.  You may also update the units of your experiments using the **Quantification Units** admin page.
 
 >![file information portion of expression loader](example_files/doc_images/expression_loader_file_info.png)
@@ -251,7 +251,7 @@ The pvalue data loader only cares about two columns (order matters):
 1. the column containing the feature names
 2. the column containing the pvalues (not the adjusted values)
 
-Copy the values from these columns (and only the values, we don't care about the headers) into a new sheet. The resulting spreadsheet should contain exactly two columns (feature name first, then pvalue) with no headers. Save the sheet as either a csv or a tsv. The resulting file should be in this format:
+Copy the values from these columns (and only the values, we don't care about the headers) into a new sheet. The resulting spreadsheet should contain exactly two columns (feature name first, then pvalue) with no headers. Save the sheet as either a csv or a tsv. The resulting file should be in this format (csv), or alternatively use tab delimiters (tsv format):
 
 ```
 FRAEX38873_v2_000000010.1,3.70E-74
@@ -324,7 +324,7 @@ Loaded expression data can be viewed and downloaded by users in three places.  *
 
 ### Downloading data
 
-Data downloads are provided for individual features, analyses, and for feature sets selected in the heatmap.  For data downloading to be functionaly, you must *populate the materialized views associated with this module*.  This can be done by navigating to Tripal -> Data Storage -> Chado -> Materialized Views.  Press the populate link for the **expression_feature** and *expression_feature_all** materialized views and run the submitted job.  Materialized views must be manually repopulated when you add new data.
+Data downloads are provided for individual features, analyses, and for feature sets selected in the heatmap.  For data downloading to be functional, you must *populate the materialized views associated with this module*.  This can be done by navigating to Tripal -> Data Storage -> Chado -> Materialized Views.  Press the populate link for the **expression_feature** and *expression_feature_all** materialized views and run the submitted job.  Materialized views must be manually repopulated when you add new data.
 
 ### Using the Feature Expression Data field
 
@@ -378,11 +378,11 @@ Note that these content types are provided by **Tripal Core**.
 
 There is currently no support for inputting, or displaying, acquisitions, quantifications, or assays.  The Expression module creates generic instances of these entities.
 
-**Protocol Descripton** - The protocol content types can be created by navigating to **Add Tripal Content->Protocol**. A protocol can be used to add extra detail to an experimental design. A protocol can be used to describe the assay, acquisition, and quantification steps of the experiment design. A protocol can also be used to further describe the array design content type. The fields of a protocol are:
+**Protocol Description** - The protocol content types can be created by navigating to **Add Tripal Content->Protocol**. A protocol can be used to add extra detail to an experimental design. A protocol can be used to describe the assay, acquisition, and quantification steps of the experiment design. A protocol can also be used to further describe the array design content type. The fields of a protocol are:
 * **Protocol Name (must be unique - required)**
 * **Protocol Link (Required)** - A web address to a page that describes the protocol.
 * **Protocol Description** - A description of the protocol.
-* **Hardware Description** - A description of the wardware used in the protocol.
+* **Hardware Description** - A description of the hardware used in the protocol.
 * **Software Description** - A description of the software used in the protocol.
 * **Protocol Type (required)** - The protocol type can acquisition, array design, assay, or quantification. The user can also create new protocol types by inserting new CVterms into the protocol type CV.
 * **Publication** - A publication that describes the protocol.

--- a/tripal_analysis_expression/includes/TripalImporter/tripal_expression_data_loader.inc
+++ b/tripal_analysis_expression/includes/TripalImporter/tripal_expression_data_loader.inc
@@ -379,7 +379,7 @@ class tripal_expression_data_loader extends TripalImporter{
   }
 
   /**
-   * Implements the function that will called as a tripal job
+   * Implements the function that will be called as a tripal job
    *  to load expression data.
    *
    * @param $organism_id
@@ -419,7 +419,7 @@ class tripal_expression_data_loader extends TripalImporter{
    *  The file extension of the expression files to be loaded.
    *
    * @param $filetype
-   *  The file type can either by mat for matrix or col for column.
+   *  The file type can be either mat for matrix or col for column.
    *
    * @param $create_biosamples
    * Allow creation of new biosamples.  Defaults to false: we want users to
@@ -703,7 +703,7 @@ AND f.type_id = :type_id', [
     // Make sure there not duplicate feature names.
     if (count($feature_repeats = array_diff_assoc($feature_array,
         array_unique($feature_array))) > 0) {
-      $this->logMessage('There are multiple instance of the following feature(s) in the expression file:');
+      $this->logMessage('There are multiple instances of the following feature(s) in the expression file:');
       foreach ($feature_repeats as $repeat) {
         $this->logMessage("  !repeat", ['!repeat' => $repeat], TRIPAL_ERROR);
       }
@@ -731,13 +731,11 @@ AND f.type_id = :type_id', [
 
     // Loop through every line in a file.
 
-    $this->logMessage("Loading complete: 0%. Memory: !memory_usage bytes. \r",
+    $this->logMessage("Loading progress: 0%. Memory: !memory_usage bytes. \r",
       ['!memory_usage' => number_format(memory_get_usage())]);
+    $time_start = microtime(TRUE);
 
     for ($j = 0; $j < $num_lines and $line = fgets($mat_fp); $j++) {
-
-      //i moved this here since $timestart is only used in the print below, but unsure of its purpose- BC
-      $time_start = microtime(TRUE);
 
       if ($j % $load_limit == 0) {
         $set_fp = ftell($mat_fp);
@@ -745,7 +743,7 @@ AND f.type_id = :type_id', [
         $time_end = microtime(TRUE);
         if ($j != 0) {
           $this->logMessage('!lps lines per second',
-            ['!lps' => $load_limit / ($time_end - $time_start)]);
+            ['!lps' => sprintf('%0.2f', $load_limit / ($time_end - $time_start))]);
         }
         $mat_fp = fopen($filepath, 'r');
         fseek($mat_fp, $set_fp);
@@ -778,7 +776,7 @@ AND f.type_id = :type_id', [
           // Make sure there not duplicate biomaterial names.
           if (count($bio_repeats = array_diff_assoc($linepart,
               array_unique($linepart))) > 0) {
-            $this->logMessage('There are multiple instance of the following biomaterial(s) in the expression file:');
+            $this->logMessage('There are multiple instances of the following biomaterial(s) in the expression file:');
             foreach ($bio_repeats as $repeat) {
               $this->logMessage('!repeat', ['!repeat' => $repeat]);
             }
@@ -794,7 +792,7 @@ AND f.type_id = :type_id', [
 
           // Make sure that there are enough expression columns.
           if ($num_col != ($num_biomaterials + 1)) {
-            $this->logMessage("Expression data in the data section of the matrix format must have a feature name followed by tab separated expression values. The number of expression values for each feature must equal the number of biomaterials in the matrix file header. Example matrix format:\n" . "  <feature name>       <expression value>	<expression value> ...");
+            $this->logMessage("Expression data in the data section of the matrix format must have a feature name followed by tab separated expression values. The number of expression values for each feature must equal the number of biomaterials in the matrix file header. Example matrix format:\n" . "  <feature name>	<expression value>	<expression value> ...");
             if (count($linepart) > 0) {
               $this->logMessage("Loader failed on the following line:\n !line\n. Expected !expected_columns columns but only found !actual_columns column(s).",
                 [
@@ -812,7 +810,7 @@ AND f.type_id = :type_id', [
 
           if ($cur_feature % $int_length == 0) {
             $percent = sprintf("%.2f", ($cur_feature / $num_features) * 100);
-            $this->logMessage("Loading complete: !percent%. Memory: !memory_usage bytes. \r",
+            $this->logMessage("Loading progress: !percent%. Memory: !memory_usage bytes. \r",
               [
                 '!percent' => $percent,
                 '!memory_usage' => number_format(memory_get_usage()),
@@ -947,7 +945,7 @@ AND f.type_id = :type_id', [
       if (preg_match('/' . $re_stop . '/', $line) and $re_stop) {
         $data_ln = 0;
       }
-      // Grab data lines. Ingore the header.
+      // Grab data lines. Ignore the header.
       if ($data_ln == 1 or !$re_start) {
         if ($col_head == 0) {
           $num_features++;
@@ -997,7 +995,7 @@ AND f.type_id = :type_id', [
       $er_id = 0;
       $af_id = 0;
 
-      $this->logMessage("Loading complete: 0%. Memory: !memory_usage bytes. \r",
+      $this->logMessage("Loading progress: 0%. Memory: !memory_usage bytes. \r",
         ['!memory_usage' => number_format(memory_get_usage())]);
 
       $col_fp = fopen($filepath, 'r');
@@ -1010,7 +1008,7 @@ AND f.type_id = :type_id', [
           $inter++;
           if ($inter % $int_length == 0) {
             $percent = sprintf("%.2f", ($inter / $num_features) * 100);
-            $this->logMessage("Loading complete: !percent%. Memory: !memory_usage bytes. \r",
+            $this->logMessage("Loading progress: !percent%. Memory: !memory_usage bytes. \r",
               [
                 '!percent' => $percent,
                 '!memory_usage' => number_format(memory_get_usage()),
@@ -1150,13 +1148,8 @@ AND f.type_id = :type_id', [
     $feature_object = $query->execute()->fetchObject();
 
     if ($feature_object->organism_id != $organism_id) {
-      $sql = "SELECT common_name, genus, species FROM {organism} WHERE organism_id = :organism_id";
-      $analysis_org = chado_query($sql,
-        [":organism_id" => $organism_id])->fetchObject();
-      $feature_org = chado_query($sql,
-        [":organism_id" => $feature_object->organism_id])->fetchObject();
-      $analysis_org_sciname = $analysis_org->genus . ' ' . $analysis_org->species;
-      $feature_org_sciname = $feature_org->genus . ' ' . $feature_org->species;
+      $analysis_org_sciname = chado_get_organism_scientific_name(chado_get_organism(['organism_id' => $organism_id], []));
+      $feature_org_sciname = chado_get_organism_scientific_name(chado_get_organism(['organism_id' => $feature_object->organism_id], []));
 
       $this->logMessage("Mismatch between the organism selected in the expression analysis and the organism of a feature from the expression file.\n
         Analysis organism: !analysis_org_sciname (!a_common_name)\n

--- a/tripal_analysis_expression/includes/TripalImporter/tripal_expression_pvalue_loader.inc
+++ b/tripal_analysis_expression/includes/TripalImporter/tripal_expression_pvalue_loader.inc
@@ -35,7 +35,7 @@ class tripal_expression_pvalue_loader extends TripalImporter
    *
    * @var array
    */
-  public static $file_types = ['csv', 'tsv'];
+  public static $file_types = ['csv', 'tsv', 'txt'];  // txt will be handled as tsv
 
   /**
    * Provides information to the user about the file upload.  Typically this
@@ -143,7 +143,8 @@ class tripal_expression_pvalue_loader extends TripalImporter
       '#title' => t('Experimental Factor'),
       '#required' => TRUE,
       '#description' => t('What is this gene responding to (e.g. heat, drought, ozone)? If the controlled vocabulary term does not show up, please ' . l('create it first.',
-          'admin/tripal/loaders/chado_vocabs/chado_cv/cvterm/add')),
+          'admin/tripal/loaders/chado_vocabs/chado_cv/cvterm/add') .
+          ' Prefix with CV if necessary e.g. cv_name|cvterm_name'),
       '#autocomplete_path' => 'admin/tripal/storage/chado/auto_name/cvterm/0',
     ];
 
@@ -180,7 +181,8 @@ class tripal_expression_pvalue_loader extends TripalImporter
       '#type' => 'textfield',
       '#title' => t('Sequence Type'),
       '#required' => TRUE,
-      '#description' => t('Please enter the Sequence Ontology (SO) term name that describes the features (e.g. gene, mRNA, polypeptide, etc...)'),
+      '#description' => t('Please enter the Sequence Ontology (SO) term name that describes the features (e.g. gene, mRNA, polypeptide, etc...)' .
+        ' Prefix with CV if necessary e.g. cv_name|cvterm_name'),
       '#autocomplete_path' => 'admin/tripal/storage/chado/auto_name/cvterm/' . $so_id,
     ];
 
@@ -210,14 +212,13 @@ class tripal_expression_pvalue_loader extends TripalImporter
       }
       if (is_dir($values['file_local'])) {
         form_set_error('file_local',
-          'File provided is a directory. Please upload a .csv file.');
+          'File provided is a directory. Please upload a .csv or .tsv file.');
 
         return;
       }
     }
-
     if (!chado_get_cvterm(['name' => $values['keyword']])) {
-      form_set_error('keyword', 'Cvterm provided does not exist.');
+      form_set_error('keyword', 'Provided cvterm "'.$values['keyword'].'" does not exist or is ambiguous.');
 
       return;
     }
@@ -242,6 +243,16 @@ class tripal_expression_pvalue_loader extends TripalImporter
       return;
     }
 
+    // determine type of file, csv, tsv, or txt and validate it
+    $file_info = pathinfo($file_path);
+    $file_ext = $file_info['extension'];
+    if (!in_array($file_ext, self::$file_types)) {
+      form_set_error('file_local',
+        'File provided must have one of the following extensions: .'.implode(' .', self::$file_types));
+
+     return;
+    }
+
     $fp = fopen($file_path, 'r');
 
     if (!$fp) {
@@ -250,9 +261,11 @@ class tripal_expression_pvalue_loader extends TripalImporter
       return;
     }
 
-    if (count(fgetcsv($fp, 0, ',')) != 2) {
+    $delimiter = $file_ext == 'csv' ? ',' : "\t";
+    $ncolumns = count(fgetcsv($fp, 0, $delimiter));
+    if ($ncolumns != 2) {
       form_set_error('file_upload',
-        'File provided contains incorrect number of columns. This importer requires that the uploaded file contain exactly two columns containing the feature name and the pvalue.');
+        'File provided contains incorrect number of columns ('.$ncolumns.'). This importer requires that the uploaded file contain exactly two columns containing the feature name and the pvalue.');
 
       return;
     }
@@ -276,6 +289,10 @@ class tripal_expression_pvalue_loader extends TripalImporter
 
     $cvterm_name = $run_args['keyword'];
     $this->cvterm_id = chado_get_cvterm(['name' => $cvterm_name])->cvterm_id;
+    if (!$this->cvterm_id) {
+      throw new Exception(t('The CV term "!cvterm_name" was not found. Please add this term',
+        ['!cvterm_name' => $cvterm_name]));
+    }
 
     $this->expression_relationship = $run_args['expression_relationship'];
     $this->expression_relationship_id = chado_get_cvterm(['name' => $this->expression_relationship])->cvterm_id;
@@ -283,8 +300,16 @@ class tripal_expression_pvalue_loader extends TripalImporter
       'cv_id' => ['name' => 'local'],
       'name' => 'evidence code',
     ])->cvterm_id;
+    if (!$this->expression_relationship_cvterm_id) {
+      throw new Exception(t('The CV term "evidence code" was not found in the CV "local". Please add this term',
+        []));
+    }
 
     $this->analysis_cvterm_id = chado_get_cvterm(['name' => 'analysis'])->cvterm_id;
+    if (!$this->analysis_cvterm_id) {
+      throw new Exception(t('The CV term "analysis" was not found. Please add this term',
+        []));
+    }
     $this->analysis_id = $run_args['analysis_id'];
 
     $organism_id = $run_args['organism_id'];
@@ -294,8 +319,16 @@ class tripal_expression_pvalue_loader extends TripalImporter
       'cv_id' => ['name' => 'OBI'],
       'name' => 'p-value',
     ])->cvterm_id;
+    if (!$this->pvalue_cvterm_id) {
+      throw new Exception(t('The CV term "p-value" was not found in the CV "OBI". Please add this term',
+        []));
+    }
 
     $this->pub_id = chado_query('SELECT pub_id FROM {pub} WHERE title IS NULL ORDER BY pub_id ASC limit 1')->fetchField();
+    if (!$this->pub_id) {
+      throw new Exception(t('The NULL placeholder publication was not found. Please add this publication entry',
+        []));
+    }
 
     $this->parseFile($file_path, $file_ext, $organism_id, $so_term);
   }
@@ -305,7 +338,7 @@ class tripal_expression_pvalue_loader extends TripalImporter
    *
    * @param string $file_path
    * @param string $file_ext
-   *  Either tsv or csv, determines delimiter for fgetcsv.
+   *  Either csv, tsv, or txt, determines delimiter for fgetcsv.
    * @param $cvterm_id
    *  The cvterm from the first word of the filename.
    *
@@ -329,7 +362,25 @@ class tripal_expression_pvalue_loader extends TripalImporter
       $bytes_read += drupal_strlen($pvalue);
       $this->setItemsHandled($bytes_read);
 
-      $type_id = chado_get_cvterm(['name' => $so_term])->cvterm_id;
+      // term can be prefixed with cv name and pipe separator e.g. cv_name|cvterm_name
+      if (strpos('|', $so_term)) {
+        $tmp = explode('|', $so_term, 2);
+        $cvname = trim($tmp[0]);
+        $termname = trim($tmp[1]);
+        $cv = chado_get_cv(['name' => $cvname]);
+        if (!$cv) {
+          throw new Exception(t('The controlled vocabulary "$cvname" does not exist.', []));
+        }
+        $term = chado_get_cvterm(['name' => $termname, 'cv_id' => $cv->cv_id]);
+      } else {
+        $termname = $so_term;
+        $term = chado_get_cvterm(['name' => $termname]);
+      }
+      if (!$term) {
+        throw new Exception(t('The controlled vocabulary term "$termname" does not exist or is ambiguous.', []));
+      }
+      $type_id = $term->cvterm_id;
+      
 
       try {
         $feature_id = $this->get_feature_id($feature_name, $organism_id,
@@ -339,7 +390,8 @@ class tripal_expression_pvalue_loader extends TripalImporter
         is_object($data) ? $this->updateData($data->feature_cvterm_id,
           $pvalue) : $this->insertData($feature_id, $pvalue);
       } catch (Exception $exception) {
-
+        throw new Exception(t('Error adding Pvalue to feature_id !feature_id. !exception',
+          ['!feature_id' => $feature_id, '!exception' => $exception]));
       }
 
 

--- a/tripal_analysis_expression/includes/analysis_expression_data_downloader.inc
+++ b/tripal_analysis_expression/includes/analysis_expression_data_downloader.inc
@@ -110,9 +110,9 @@ class analysis_expression_data_downloader{
    */
   public function create() {
     // Make sure the user directory exists
-    $user_dir = 'public://expression_download';
+    $user_dir = tripal_get_files_dir('tripal_analysis_expression_download');
     if (!file_prepare_directory($user_dir, FILE_CREATE_DIRECTORY)) {
-      $message = 'Could not access the directory on the server for storing this file.';
+      $message = 'Could not access the directory '.$user_dir.' for storing this file.';
       watchdog('tripal', $message, [], WATCHDOG_ERROR);
       return;
     }

--- a/tripal_analysis_expression/includes/feature_heatmap_form.inc
+++ b/tripal_analysis_expression/includes/feature_heatmap_form.inc
@@ -131,7 +131,7 @@ function feature_heatmap_form($form, &$form_state) {
     ],
   ];
 
-  // Escaped get value if it exists
+  // Escape get value if it exists
   if (isset($_GET['heatmap_feature_uniquename']) && !empty($_GET['heatmap_feature_uniquename'])) {
     $form['heatmap_feature_uniquename']['#value'] = $_GET['heatmap_feature_uniquename'];
   }
@@ -343,19 +343,22 @@ function feature_heatmap_get_organisms() {
     return drupal_map_assoc(tripal_elasticsearch_get_gene_search_organisms());
   }
 
-  $sql = 'SELECT genus, species, common_name, organism_id
-            FROM {organism} 
-            ORDER BY genus ASC, species ASC';
+  $sql = 'SELECT * FROM {organism} ORDER BY genus ASC, species ASC';
 
   $organism_list = chado_query($sql)->fetchAll();
 
   $organisms = [];
   foreach ($organism_list as $organism) {
-    $organisms[$organism->organism_id] = "$organism->genus $organism->species";
+    $organisms[$organism->organism_id] = chado_get_organism_scientific_name($organism);
     if (!empty($organism->common_name)) {
       $organisms[$organism->organism_id] .= " ($organism->common_name)";
     }
   }
+
+  // if the site uses the chado infraspecific nomenclature, organisms will not be fully
+  // alphabetically sorted by subspecies names, but we can't include in the SQL easily
+  // because the columns may not be present, so sort the list again by scientific name
+  natcasesort($organisms);
 
   return $organisms;
 }

--- a/tripal_analysis_expression/includes/tripal_analysis_expression.api.inc
+++ b/tripal_analysis_expression/includes/tripal_analysis_expression.api.inc
@@ -70,10 +70,10 @@ function tripal_analysis_expression_get_protocol_select_options($protocol_type) 
  *   Returns the file path to the new location of the file.
  */
 function tripal_analysis_expression_cache_file($file_path) {
-  $destination = 'public://expression';
+  $destination = tripal_get_files_dir('tripal_analysis_expression');
   if (!file_prepare_directory($destination, FILE_CREATE_DIRECTORY)) {
     tripal_report_error('tripal_analysis_expression', TRIPAL_ERROR,
-      "Could not create directory at $destination, please check your permissions and try again.\n",
+      "Could not create directory $destination, please check your permissions and try again.\n",
       [], ['print' => TRUE]);
     return FALSE;
   }

--- a/tripal_analysis_expression/tripal_analysis_expression.install
+++ b/tripal_analysis_expression/tripal_analysis_expression.install
@@ -34,6 +34,10 @@ function tripal_analysis_expression_requirements($phase) {
  * @ingroup tripal_analysis_module
  */
 function tripal_analysis_expression_install() {
+  // data directories for upload and download
+  tripal_create_files_dir('tripal_analysis_expression');
+  tripal_create_files_dir('tripal_analysis_expression_download');
+
   // Insert term used for fields
   tripal_insert_cvterm([
     'id' => 'data:2603',

--- a/tripal_biomaterial/api/tripal_biomaterial.api.inc
+++ b/tripal_biomaterial/api/tripal_biomaterial.api.inc
@@ -228,7 +228,7 @@ function expression_create_biomaterial_structure($biomaterial, $organism_id, $an
         'id' => 'sep:00056',
         'name' => 'unit_of_measure',
         'cv_name' => 'sep',
-        'definition' => 'A unit of measure is a quantity which is a standard of measurement for some dimension. For example, the Meter is a Unit O fMeasure for the dimension of length, as is the Inch. There is no intrinsic property of a UnitOfMeasure that makes it primitive or fundamental; rather, a system of units (e.g. Systeme International Unit) defines a set of orthogonal dimensions and assigns units for each. [ SUMO:unit of measure ]',
+        'definition' => 'A unit of measure is a quantity which is a standard of measurement for some dimension. For example, the Meter is a Unit Of Measure for the dimension of length, as is the Inch. There is no intrinsic property of a UnitOfMeasure that makes it primitive or fundamental; rather, a system of units (e.g. Systeme International Unit) defines a set of orthogonal dimensions and assigns units for each. [ SUMO:unit of measure ]',
       ])->cvterm_id;
     }
 
@@ -602,12 +602,18 @@ function tripal_biomaterial_create_biomaterial($biomaterial, $analysis_id, $orga
     if ($biomaterial_result->taxon_id && $warnings) {
       print("WARNING: Biomaterial with sample_name of '$biomaterial' alreay exists in the database. Overwriting database entries for $biomaterial...\n");
       if ($biomaterial_result->taxon_id and $biomaterial_result->taxon_id != $organism_id) {
-        $sql = "SELECT common_name, genus, species FROM {organism} WHERE organism_id = :organism_id";
-        $analysis_org = chado_query($sql,
-          [":organism_id" => $organism_id])->fetchObject();
-        $biomaterial_org = chado_query($sql,
-          [":organism_id" => $biomaterial_result->taxon_id])->fetchObject();
-        print "ERROR: Mismatch between the organism selected in the loader " . "and the organism of a biomaterial in the Chado database.\n" . "  Organism selected by loader: " . $analysis_org->genus . " " . $analysis_org->species . " (" . $analysis_org->common_name . ")\n" . "  Biomaterial organism: " . $biomaterial_org->genus . " " . $biomaterial_org->species . " (" . $biomaterial_org->common_name . ")\n" . "  On biomaterial: " . $biomaterial . "\n" . "Please ensure that the organism selected by the loader " . "and the organism for each biomaterial in the file to be loaded " . "are the same. If these organisms should not be the same, " . "delete the offending biomaterial in Chado or change the name of " . "the biomaterial to another unique name.\n";
+        $analysis_taxon = chado_get_organism_scientific_name(chado_get_organism(['organism_id' => $organism_id], []));
+        $biomaterial_taxon = chado_get_organism_scientific_name(chado_get_organism(['organism_id' => $biomaterial_result->taxon_id], []));
+        print "ERROR: Mismatch between the organism selected in the loader " .
+          "and the organism of a biomaterial in the Chado database.\n" .
+          "  Organism selected by loader: " . $analysistaxon . "\n" .
+          "  Biomaterial organism: " . $biomaterial_taxon . "\n" .
+          "  On biomaterial: " . $biomaterial . "\n" .
+          "Please ensure that the organism selected by the loader " .
+          "and the organism for each biomaterial in the file to be loaded " .
+          "are the same. If these organisms should not be the same, " .
+          "delete the offending biomaterial in Chado or change the name of " .
+          "the biomaterial to another unique name.\n";
         exit;
       }
     }


### PR DESCRIPTION
This pull request is to fix problems noted in issue #364 

- P-value loader does not currently work with .tsv files.  
  Bugs fixed to correct this

- Two hardcoded paths 'public://expression_download' and 'public://expression' are present in the module. These don't exist generally.  
  These have been converted to relative paths, and are created by the installer  
  ```tripal_create_files_dir('tripal_analysis_expression');```  
  ```tripal_create_files_dir('tripal_analysis_expression_download');```
Perhaps these should become configuration variables editable in the admin module. A future project?

- No support for infraspecific nomenclature.  
  Support added

- Loading message indicates impossibly large number of lines processed per second.  
  ```$time_start = microtime(TRUE);``` was in the wrong place  
  ```Loading complete:``` changed to ```Loading progress:```
- Cannot use cv term if present in more than one cv.  
  cv term may now be prefixed with cv name when necessary, e.g. ```cvname|cvterm```

- assorted corrections to typos