### PR TITLE
Fix for issue Biosample CSV importer

### DIFF
--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -593,7 +593,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     $fp = fopen($file_path, "r");
     while ($line = fgetcsv($fp, 0, $separator, $enclosure)) {
       foreach ($line as $field) {
-        if (preg_match("/(sample_name)/", $field)) {
+        if (preg_match("/(sample[_\s]name)/i", $field)) {
           break 2;
         }
       }
@@ -615,7 +615,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
 
     while ($line = fgetcsv($fp, 0, $separator, $enclosure)) {
       foreach ($line as $field) {
-        if (preg_match("/(sample_name)/", $field)) {
+        if (preg_match("/(sample[_\s]name)/i", $field)) {
           break 2;
         }
       }
@@ -639,7 +639,8 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     $acc_headers = [];
 
     for ($i = 0; $i < count($headers); $i++) {
-      $header = trim(str_replace("*", "", $headers[$i]));
+      $header = preg_replace('/[^\w]/', '_', strtolower($headers[$i]));
+      //$header = trim(str_replace("*", "", $headers[$i]));
       if ($header == 'sample_name') {
         $biomaterial_headers['sample_name'] = $i;
       }
@@ -1051,14 +1052,17 @@ function test_biosample_cvterms_flat(
     return;
   }
 
-  $attribute_list["values"] = [];
+  // Get the column headers that need CVterms. We will exclude those
+  // that we already know the terms for.
+  $attribute_list["attributes"] = [];
   for ($i = 0; $i < count($headers); $i++) {
-    $header = trim(str_replace("*", "", $headers[$i]));
+    $header = preg_replace('/[^\w]/', '_', strtolower($headers[$i]));
+    //$header = trim(str_replace("*", "", $headers[$i]));
     if (in_array($header, [
       'sample_name',
       'organism',
       'description',
-      ' biomaterial_provider',
+      'biomaterial_provider',
       'biomaterial_accession',
       'sra_accession',
       'bioproject_accession',
@@ -1070,14 +1074,17 @@ function test_biosample_cvterms_flat(
   }
 
   // Fill the values into the attribute_list array from lines in the file. Starting from the next line after the header
-  $tmpNumLine = 0;
-  while ($line = fgetcsv($fp, 0, $separator, $enclosure)) {
-    $tmpNumLine++;
-    if($tmpNumLine > $nLineHeader){
-      $attribute_list["values"] = array_merge($attribute_list["values"], $line);
-    }
-  }
-  $attribute_list["values"] = array_unique($attribute_list["values"]);
+//  TODO: the following code adds every value of every column as a potential term
+// which from aN NCBI SRA file that overruns the page!
+//   $attribute_list["values"] = [];
+//   $tmpNumLine = 0;
+//   while ($line = fgetcsv($fp, 0, $separator, $enclosure)) {
+//     $tmpNumLine++;
+//     if($tmpNumLine > $nLineHeader){
+//       $attribute_list["values"] = array_merge($attribute_list["values"], $line);
+//     }
+//   }
+//   $attribute_list["values"] = array_unique($attribute_list["values"]);
 
   return ($attribute_list);
 }

--- a/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
+++ b/tripal_biomaterial/includes/TripalImporter/tripal_biomaterial_loader_v3.inc
@@ -93,9 +93,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     if ((isset($form_state['values']['file_local'])) || isset($form_state['values']['file_upload']) || isset($form_state['values']['file_upload_existing'])) {
       $file_path = $this->findFile($form_state['values']);
 
-      $extension = explode('.', $file_path);
-      $extension = $extension[count($extension) - 1];
-      $file_type = $extension;
+      $file_type = pathinfo($file_path, PATHINFO_EXTENSION);
       $organism_id = $form_state['values']['organism_id'];
       $analysis_id = $form_state['values']['analysis_id'];
       $link = variable_get('website_base_url') . "admin/tripal/loaders/chado_cv/cvterm/add.";
@@ -108,8 +106,10 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       else {
         $terms_to_check = test_biosample_cvterms_flat($file_path);
       }
-      $fields = $terms_to_check["attributes"];
-      $property_values = $terms_to_check["values"];
+      if ($terms_to_check) {
+        $fields = $terms_to_check["attributes"];
+        $property_values = $terms_to_check["values"];
+      }
     }
 
     $form['cvterms'] = [
@@ -307,12 +307,10 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
     }
 
     if (array_key_exists('file_remote', $this->arguments['files'][0])) {
-      $extension = explode('.', $this->arguments['files'][0]['file_remote']);
-      $extension = $extension[count($extension) - 1];
+      $extension = pathinfo($this->arguments['files'][0]['file_remote'], PATHINFO_EXTENSION);
     }
     else {
-      $extension = explode('.', $file_path);
-      $extension = $extension[count($extension) - 1];
+      $extension = pathinfo($file_path, PATHINFO_EXTENSION);
     }
 
     if ($extension == "xml") {
@@ -580,8 +578,7 @@ class tripal_biomaterial_loader_v3 extends TripalImporter {
       return;
     }
 
-    $extension = explode('.', $file_path);
-    $extension = $extension[count($extension) - 1];
+    $extension = pathinfo($file_path, PATHINFO_EXTENSION);
 
     // Defaults are for csv unless tsv selected.
     $separator = ",";
@@ -982,15 +979,17 @@ function test_biosample_cvterms_flat(
   // Check if the file given is empty.
   $fileSize = filesize($file_path);
   if ($fileSize == 0) {
-
-   error_log("File at !file_path is empty. Try again with a new file. file_path: $file_path", 0);
+    tripal_report_error('tripal_analysis_expression', TRIPAL_ERROR,
+        "File at !file_path is empty. Try again with a new file. file_path: !file_path",
+        ['!file_path' => $file_path],
+        ['drupal_set_message' => TRUE]);
    #$this->logMessage("File at !file_path is empty. Try again with a new file.",
    #   ['!file_path' => $file_path], TRIPAL_ERROR);
     return;
   }
+
   // Figure out CSV vs TSV.
-  $extension = explode('.', $file_path);
-  $extension = $extension[count($extension) - 1];
+  $extension = pathinfo($file_path, PATHINFO_EXTENSION);
 
   if ($extension == "tsv") {
     $separator = "\t";
@@ -1006,7 +1005,7 @@ function test_biosample_cvterms_flat(
   $fp = fopen($file_path, "r");
   while ($line = fgetcsv($fp, 0, $separator, $enclosure)) {
     foreach ($line as $field) {
-      if (preg_match("/(sample_name)/", $field)) {
+      if (preg_match("/(sample[_\s]name)/i", $field)) {
         break 2;
       }
     }
@@ -1020,11 +1019,15 @@ function test_biosample_cvterms_flat(
 
   // Print error message and exit if there's no biosample, or that there's no "sample_name" column in flat file.
   if ($num_biosamples == 0) {
-    error_log("Wrong file format at !file_path. File must contain a column named 'sample_name'. $file_path", 0);
     #$this->logMessage("Wrong file format at !file_path. File must contain a column named 'sample_name'.",
     #  ['!file_path' => $file_path], TRIPAL_ERROR);
+    tripal_report_error('tripal_analysis_expression', TRIPAL_ERROR,
+        "Wrong file format of !file_path. The file must contain a column named 'sample_name'",
+        ['!file_path' =>  pathinfo($file_path, PATHINFO_FILENAME)],
+        ['drupal_set_message' => TRUE]);
     return;
   }
+
 
   // Get the file pointer.
   $fp = fopen($file_path, "r");
@@ -1032,7 +1035,7 @@ function test_biosample_cvterms_flat(
   while ($line = fgetcsv($fp, 0, $separator, $enclosure)) {
     $nLineHeader++;
     foreach ($line as $field) {
-      if (preg_match("/(sample_name)/", $field)) {
+      if (preg_match("/(sample[_\s]name)/i", $field)) {
         break 2;
       }
     }
@@ -1041,8 +1044,10 @@ function test_biosample_cvterms_flat(
 
   // Make sure there are not duplicate biomaterial headers.
   if (count($header_repeats = array_diff_assoc($headers, array_unique($headers))) > 0) {
-    $this->logMessage("The header !header is present more than once.  Please make sure there is only one instance of each header.",
-      ['!header' => $header_repeats[0]], TRIPAL_ERROR);
+    tripal_report_error('tripal_analysis_expression', TRIPAL_ERROR,
+      "The header !header is present more than once.  Please make sure there is only one instance of each header.",
+      ['!header' => $header_repeats[0]],
+      ['drupal_set_message' => TRUE]);
     return;
   }
 


### PR DESCRIPTION
This PR primarily fixes an issue described in issue #381 .   Basically it adjusts the regular expression that finds the sample name column to support any variation of the phrase "Sample name".

This PR also fixes a few bugs I found 
1.  There were issues with logging errors.  One problem I had was that no meaningful error messages were displayed when the problem occurred.  I fixed it by using the `tripal_report_error` function in place of the `log_error` function. 
2. Also there was some places where the `$this->logError` function was used in a function that was outside of the class. I changed that to use the `tripal_report_error` function.
3. There were multiple places where the file extension was excluded from the filename. The code was multiple lines and could be easily reduced to 1 line by using the `pathinfo` function. I couldn't resist that change.
4. There were some cases where I got error messages in my report log because the code was expecting an array but got a scalar boolean back from the function call.  I wrapped those in if statements to prevent the errors from filling the log.