### PR TITLE
Issue #419 sql returns only organisms with expression data

### DIFF
--- a/tripal_analysis_expression/includes/feature_heatmap_form.inc
+++ b/tripal_analysis_expression/includes/feature_heatmap_form.inc
@@ -343,7 +343,10 @@ function feature_heatmap_get_organisms() {
     return drupal_map_assoc(tripal_elasticsearch_get_gene_search_organisms());
   }
 
-  $sql = 'SELECT * FROM {organism} ORDER BY genus ASC, species ASC';
+  // subquery here is faster than a join
+  $sql = 'SELECT * FROM {organism} WHERE organism_id IN
+    (SELECT DISTINCT organism_id FROM {expression_feature})
+    ORDER BY genus ASC, species ASC';
 
   $organism_list = chado_query($sql)->fetchAll();
 


### PR DESCRIPTION
This single change now shows only organisms with expression data in the heatmap query form at ```/tripal_expression```, using only organisms present in the ```expression_feature``` table.

As an aside, this form ```SELECT DISTINCT O.* FROM expression_feature EF LEFT JOIN organism O on EF.organism_id=O.organism_id;``` was noticeably slower, so I used a subquery.