### PR TITLE
Move up initialization of [0]['value'], issue #421

### DIFF
--- a/tripal_analysis_expression/includes/TripalFields/data__gene_expression_data/data__gene_expression_data.inc
+++ b/tripal_analysis_expression/includes/TripalFields/data__gene_expression_data/data__gene_expression_data.inc
@@ -95,6 +95,9 @@ class data__gene_expression_data extends ChadoField{
     $record = $entity->chado_record;
     $chado_table = $entity->chado_table;
     $field_name = $this->field['field_name'];
+
+    // Set some defaults for the empty record.
+    $entity->{$field_name}['und'][0]['value'] = [];
     
     // Get the list of analyses
     $analyses = [];
@@ -126,7 +129,6 @@ class data__gene_expression_data extends ChadoField{
     }
     
     if (count(array_keys($analyses)) == 0) {
-      $entity->{$field_name}['und'][0]['value'] = [];
       return $entity;
     }
 

--- a/tripal_analysis_expression/includes/TripalFields/data__gene_expression_data/data__gene_expression_data_formatter.inc
+++ b/tripal_analysis_expression/includes/TripalFields/data__gene_expression_data/data__gene_expression_data_formatter.inc
@@ -53,7 +53,7 @@ class data__gene_expression_data_formatter extends ChadoFieldFormatter{
       $aname = $item['operation:2945']['schema:name'];
       $data_link = $item['schema:DataDownload'];
       
-      // Itereate throught he descriptive statistics
+      // Iterate through the descriptive statistics
       foreach ($item['AFP:0003636'] as $stat) {
         $type = $stat['NCIT:C25284'];
         $quantity = $stat['NCIT:C25463'];


### PR DESCRIPTION
Simple fix for issue #421, move up the initialization of ```$entity->{$field_name}['und'][0]['value']``` so that it is always initialized.
