### PR TITLE
Issue 426 feature_cvtermprop value not always an integer

### DIFF
--- a/tripal_analysis_expression/includes/TripalFields/local__expression_details/local__expression_details.inc
+++ b/tripal_analysis_expression/includes/TripalFields/local__expression_details/local__expression_details.inc
@@ -122,11 +122,10 @@ class local__expression_details extends ChadoField{
     $pvalue_data = chado_query('SELECT cv1.name as cvterm_name, cv1.cvterm_id as cvterm_id, p1.value as expression_relationship, p2.value as p_value, a.name as analysis_name, a.analysis_id as analysis_id
   FROM {feature_cvterm} fcvt
   JOIN {cvterm} cv1 ON cv1.cvterm_id=fcvt.cvterm_id
-  JOIN {cvterm} cv2 ON cv2.name=\'analysis\'
   JOIN {feature_cvtermprop} p1 ON p1.feature_cvterm_id=fcvt.feature_cvterm_id AND p1.type_id=:evidence_id
   JOIN {feature_cvtermprop} p2 ON p2.feature_cvterm_id=fcvt.feature_cvterm_id AND p2.type_id=:pvalue_id
-  JOIN {feature_cvtermprop} p3 ON p3.feature_cvterm_id=fcvt.feature_cvterm_id AND p3.type_id=cv2.cvterm_id
-  JOIN {analysis} a ON a.analysis_id=p3.value::INTEGER
+  JOIN {feature_cvtermprop} p3 ON p3.feature_cvterm_id=fcvt.feature_cvterm_id AND p3.type_id=(select cvterm_id from {cvterm} where name=\'analysis\')
+  JOIN {analysis} a ON a.analysis_id::TEXT=p3.value
   WHERE fcvt.feature_id = :feature_id', [
       ':feature_id' => $feature_id,
       ':evidence_id' => $evidence_code_cvterm_id,


### PR DESCRIPTION
Issue #426 

change the cast from p3.value to integer, which can fail, to a text cast on a.analysis_id

also change the JOIN for cv2 into a subquery as it was still problematic as it was, too much was joined.